### PR TITLE
Joseph fixing things

### DIFF
--- a/Assets/Prefabs/ArcTurret.prefab
+++ b/Assets/Prefabs/ArcTurret.prefab
@@ -12,6 +12,7 @@ GameObject:
   - 65: {fileID: 6564850}
   - 23: {fileID: 2354948}
   - 114: {fileID: 11440812}
+  - 114: {fileID: 11430106}
   m_Layer: 0
   m_Name: ArcTurret
   m_TagString: Untagged
@@ -26,7 +27,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 112256}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -51.16, y: 0, z: 0}
+  m_LocalPosition: {x: -62.441242, y: 2.3, z: 10.211057}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -76,6 +77,19 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &11430106
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 112256}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9331beb602b6d7d438fc519136308340, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  bulletPrefab: {fileID: 194514, guid: 83272a788fdf7664c84301dc9014b262, type: 2}
+  target: {fileID: 0}
 --- !u!114 &11440812
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -99,7 +113,11 @@ Prefab:
     - target: {fileID: 0}
       propertyPath: bulletPrefab
       value: 
-      objectReference: {fileID: 100204, guid: 2e80d5d9eb66a03468047b0ba2be3928, type: 2}
+      objectReference: {fileID: 194514, guid: 83272a788fdf7664c84301dc9014b262, type: 2}
+    - target: {fileID: 0}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 0}
   m_RootGameObject: {fileID: 112256}

--- a/Assets/Prefabs/ArcTurret.prefab
+++ b/Assets/Prefabs/ArcTurret.prefab
@@ -12,14 +12,13 @@ GameObject:
   - 65: {fileID: 6564850}
   - 23: {fileID: 2354948}
   - 114: {fileID: 11440812}
-  - 114: {fileID: 11430106}
   m_Layer: 0
   m_Name: ArcTurret
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &490520
 Transform:
   m_ObjectHideFlags: 1
@@ -77,19 +76,6 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
---- !u!114 &11430106
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 112256}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9331beb602b6d7d438fc519136308340, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  bulletPrefab: {fileID: 194514, guid: 83272a788fdf7664c84301dc9014b262, type: 2}
-  target: {fileID: 0}
 --- !u!114 &11440812
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/Blip.prefab
+++ b/Assets/Prefabs/Blip.prefab
@@ -25,7 +25,7 @@ Transform:
   m_GameObject: {fileID: 154652}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -15.6, y: 1.7699999, z: -1.3}
-  m_LocalScale: {x: 0.2, y: 0.2, z: 0.2}
+  m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -84,6 +84,18 @@ Prefab:
     - target: {fileID: 0}
       propertyPath: m_TagString
       value: UI
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_LocalScale.x
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_LocalScale.y
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_LocalScale.z
+      value: 0.1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 0}

--- a/Assets/Prefabs/Bullet.prefab
+++ b/Assets/Prefabs/Bullet.prefab
@@ -145,7 +145,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bb0a7de91fd123043ad2ada49a57377e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  decal: {fileID: 106938, guid: 7eef142717ab9324f9cdbd816be9677f, type: 2}
   brackets: {fileID: 0}
 --- !u!114 &11420726
 MonoBehaviour:
@@ -335,10 +334,6 @@ Prefab:
       propertyPath: m_LocalScale.z
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 0}
-      propertyPath: decal
-      value: 
-      objectReference: {fileID: 106938, guid: 7eef142717ab9324f9cdbd816be9677f, type: 2}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 0}
   m_RootGameObject: {fileID: 181106}

--- a/Assets/Prefabs/Canvas.prefab
+++ b/Assets/Prefabs/Canvas.prefab
@@ -15,7 +15,7 @@ GameObject:
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
-  m_StaticEditorFlags: 4294967295
+  m_StaticEditorFlags: 0
   m_IsActive: 1
 --- !u!1 &121466
 GameObject:
@@ -29,11 +29,11 @@ GameObject:
   - 114: {fileID: 11483052}
   - 114: {fileID: 11471974}
   m_Layer: 5
-  m_Name: MidAreaButton
+  m_Name: RoomTestButton
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
-  m_StaticEditorFlags: 4294967295
+  m_StaticEditorFlags: 0
   m_IsActive: 1
 --- !u!1 &124262
 GameObject:
@@ -50,7 +50,7 @@ GameObject:
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
-  m_StaticEditorFlags: 4294967295
+  m_StaticEditorFlags: 0
   m_IsActive: 1
 --- !u!1 &148958
 GameObject:
@@ -67,25 +67,7 @@ GameObject:
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
-  m_StaticEditorFlags: 4294967295
-  m_IsActive: 1
---- !u!1 &153996
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
-  m_Component:
-  - 224: {fileID: 22483846}
-  - 222: {fileID: 22294728}
-  - 114: {fileID: 11444158}
-  - 114: {fileID: 11425056}
-  m_Layer: 5
-  m_Name: EndGameButton
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 4294967295
+  m_StaticEditorFlags: 0
   m_IsActive: 1
 --- !u!1 &165190
 GameObject:
@@ -102,24 +84,7 @@ GameObject:
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
-  m_StaticEditorFlags: 4294967295
-  m_IsActive: 1
---- !u!1 &169784
-GameObject:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
-  m_Component:
-  - 224: {fileID: 22455832}
-  - 222: {fileID: 22202826}
-  - 114: {fileID: 11478598}
-  m_Layer: 5
-  m_Name: Text
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 4294967295
+  m_StaticEditorFlags: 0
   m_IsActive: 1
 --- !u!1 &181720
 GameObject:
@@ -138,7 +103,7 @@ GameObject:
   m_TagString: UI
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
-  m_StaticEditorFlags: 4294967295
+  m_StaticEditorFlags: 0
   m_IsActive: 1
 --- !u!1 &195646
 GameObject:
@@ -152,11 +117,11 @@ GameObject:
   - 114: {fileID: 11419706}
   - 114: {fileID: 11402112}
   m_Layer: 5
-  m_Name: EntranceButton
+  m_Name: RaceTrackButton
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
-  m_StaticEditorFlags: 4294967295
+  m_StaticEditorFlags: 0
   m_IsActive: 1
 --- !u!1 &196806
 GameObject:
@@ -173,7 +138,7 @@ GameObject:
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
-  m_StaticEditorFlags: 4294967295
+  m_StaticEditorFlags: 0
   m_IsActive: 1
 --- !u!114 &11402112
 MonoBehaviour:
@@ -222,7 +187,7 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument: 01-Entrance
+          m_StringArgument: RaceTrack
           m_BoolArgument: 0
         m_CallState: 1
     m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
@@ -303,58 +268,6 @@ MonoBehaviour:
   m_FillAmount: 1
   m_FillClockwise: 1
   m_FillOrigin: 0
---- !u!114 &11425056
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 153996}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 1392445389, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Navigation:
-    m_Mode: 3
-    m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
-    m_SelectOnLeft: {fileID: 0}
-    m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
-  m_Colors:
-    m_NormalColor: {r: 0.9490197, g: 0.87843144, b: 0.5921569, a: 1}
-    m_HighlightedColor: {r: 0.8308824, g: 0.60075855, b: 0.11607917, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
-    m_ColorMultiplier: 1
-    m_FadeDuration: 0.1
-  m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_DisabledSprite: {fileID: 0}
-  m_AnimationTriggers:
-    m_NormalTrigger: Normal
-    m_HighlightedTrigger: Highlighted
-    m_PressedTrigger: Pressed
-    m_DisabledTrigger: Disabled
-  m_Interactable: 1
-  m_TargetGraphic: {fileID: 11444158}
-  m_OnClick:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 11436394}
-        m_MethodName: LoadScene
-        m_Mode: 5
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 03-EndGame
-          m_BoolArgument: 0
-        m_CallState: 1
-    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
-      Culture=neutral, PublicKeyToken=null
 --- !u!114 &11436394
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -366,33 +279,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 215e669212ac4ae4a9dc848da4ea695d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &11444158
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 153996}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0.2647059, g: 0.23313625, b: 0.10510382, a: 0.584}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
 --- !u!114 &11444840
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -473,7 +359,7 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument: 02-MidArea
+          m_StringArgument: RoomTest
           m_BoolArgument: 0
         m_CallState: 1
     m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
@@ -525,39 +411,6 @@ MonoBehaviour:
     y: 0
     width: 1
     height: 1
---- !u!114 &11478598
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 169784}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0.9490197, g: 0.87843144, b: 0.5921569, a: 1}
-  m_RaycastTarget: 0
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 20
-    m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 10
-    m_MaxSize: 53
-    m_Alignment: 4
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 1
-    m_LineSpacing: 1
-  m_Text: Load End Game
 --- !u!114 &11483052
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -617,7 +470,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 1
     m_LineSpacing: 1
-  m_Text: Load Mid Area
+  m_Text: Load RoomTest
 --- !u!114 &11489992
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -650,13 +503,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 1
     m_LineSpacing: 1
-  m_Text: Load Entrance
---- !u!222 &22202826
-CanvasRenderer:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 169784}
+  m_Text: Load RaceTrack
 --- !u!222 &22207998
 CanvasRenderer:
   m_ObjectHideFlags: 1
@@ -699,12 +546,6 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 195646}
---- !u!222 &22294728
-CanvasRenderer:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 153996}
 --- !u!223 &22306298
 Canvas:
   m_ObjectHideFlags: 1
@@ -810,23 +651,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!224 &22455832
-RectTransform:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 169784}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 22483846}
-  m_RootOrder: 0
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &22477694
 RectTransform:
   m_ObjectHideFlags: 1
@@ -842,24 +666,6 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: -274, y: 99}
-  m_SizeDelta: {x: 160, y: 30}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!224 &22483846
-RectTransform:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 153996}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 22455832}
-  m_Father: {fileID: 22494962}
-  m_RootOrder: 5
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -276, y: -122}
   m_SizeDelta: {x: 160, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &22492756
@@ -894,7 +700,6 @@ RectTransform:
   - {fileID: 22477694}
   - {fileID: 22420138}
   - {fileID: 22492756}
-  - {fileID: 22483846}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_AnchorMin: {x: 0, y: 0}

--- a/Assets/Prefabs/DoubleHelixTurret.prefab
+++ b/Assets/Prefabs/DoubleHelixTurret.prefab
@@ -12,7 +12,6 @@ GameObject:
   - 65: {fileID: 6582772}
   - 23: {fileID: 2337882}
   - 114: {fileID: 11443196}
-  - 114: {fileID: 11482112}
   m_Layer: 0
   m_Name: DoubleHelixTurret
   m_TagString: Untagged
@@ -95,23 +94,6 @@ MonoBehaviour:
   fireOnlyWhenPlayerNear: 0
   BARREL_SEPARATION: 4
   ROTATION_ANGLE: {x: 0, y: 0, z: 15}
-  bulletPosition: {x: 0, y: 0, z: 0}
---- !u!114 &11482112
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 130172}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 272d6d8d124654741baf475f3c8937d9, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  bulletPrefab: {fileID: 194514, guid: 83272a788fdf7664c84301dc9014b262, type: 2}
-  focusPoint: {x: 0, y: 0, z: 0}
-  target: {fileID: 0}
-  sensorRange: 5
-  fireOnlyWhenPlayerNear: 0
   bulletPosition: {x: 0, y: 0, z: 0}
 --- !u!1001 &100100000
 Prefab:

--- a/Assets/Prefabs/DoubleHelixTurret.prefab
+++ b/Assets/Prefabs/DoubleHelixTurret.prefab
@@ -12,6 +12,7 @@ GameObject:
   - 65: {fileID: 6582772}
   - 23: {fileID: 2337882}
   - 114: {fileID: 11443196}
+  - 114: {fileID: 11482112}
   m_Layer: 0
   m_Name: DoubleHelixTurret
   m_TagString: Untagged
@@ -26,7 +27,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 130172}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -54.74, y: 0.578125, z: -26.6}
+  m_LocalPosition: {x: 0.1, y: 0, z: -26.6}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -89,6 +90,28 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   bulletPrefab: {fileID: 100204, guid: 2e80d5d9eb66a03468047b0ba2be3928, type: 2}
   focusPoint: {x: 0, y: 0, z: 0}
+  target: {fileID: 0}
+  sensorRange: 30
+  fireOnlyWhenPlayerNear: 0
+  BARREL_SEPARATION: 4
+  ROTATION_ANGLE: {x: 0, y: 0, z: 15}
+  bulletPosition: {x: 0, y: 0, z: 0}
+--- !u!114 &11482112
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 130172}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 272d6d8d124654741baf475f3c8937d9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  bulletPrefab: {fileID: 194514, guid: 83272a788fdf7664c84301dc9014b262, type: 2}
+  focusPoint: {x: 0, y: 0, z: 0}
+  target: {fileID: 0}
+  sensorRange: 5
+  fireOnlyWhenPlayerNear: 0
   bulletPosition: {x: 0, y: 0, z: 0}
 --- !u!1001 &100100000
 Prefab:
@@ -100,7 +123,11 @@ Prefab:
     - target: {fileID: 0}
       propertyPath: bulletPrefab
       value: 
-      objectReference: {fileID: 100204, guid: 2e80d5d9eb66a03468047b0ba2be3928, type: 2}
+      objectReference: {fileID: 194514, guid: 83272a788fdf7664c84301dc9014b262, type: 2}
+    - target: {fileID: 0}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 0}
   m_RootGameObject: {fileID: 130172}

--- a/Assets/Prefabs/FountainTurret.prefab
+++ b/Assets/Prefabs/FountainTurret.prefab
@@ -12,14 +12,13 @@ GameObject:
   - 65: {fileID: 6528362}
   - 23: {fileID: 2357802}
   - 114: {fileID: 11494060}
-  - 114: {fileID: 11494766}
   m_Layer: 0
   m_Name: FountainTurret
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &467358
 Transform:
   m_ObjectHideFlags: 1
@@ -95,26 +94,6 @@ MonoBehaviour:
   fireOnlyWhenPlayerNear: 0
   NUM_BARRELS: 20
   ORIG_TURRET_RADIUS: 4
-  MAX_SWIVEL: 1.0471976
-  SWIVEL_PERCENTAGE: 0.1
---- !u!114 &11494766
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 149390}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5d47e790c2d47dc47b3f19befe4cc485, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  bulletPrefab: {fileID: 194514, guid: 83272a788fdf7664c84301dc9014b262, type: 2}
-  focusPoint: {x: 0, y: 0, z: 0}
-  target: {fileID: 0}
-  sensorRange: 30
-  fireOnlyWhenPlayerNear: 0
-  NUM_BARRELS: 20
-  ORIG_TURRET_RADIUS: 10
   MAX_SWIVEL: 1.0471976
   SWIVEL_PERCENTAGE: 0.1
 --- !u!1001 &100100000

--- a/Assets/Prefabs/FountainTurret.prefab
+++ b/Assets/Prefabs/FountainTurret.prefab
@@ -12,6 +12,7 @@ GameObject:
   - 65: {fileID: 6528362}
   - 23: {fileID: 2357802}
   - 114: {fileID: 11494060}
+  - 114: {fileID: 11494766}
   m_Layer: 0
   m_Name: FountainTurret
   m_TagString: Untagged
@@ -26,7 +27,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 149390}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 2.925, y: -1, z: 233.16}
+  m_LocalPosition: {x: -51.6, y: 3, z: -21.3}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -87,10 +88,33 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d7cf0cba967c4e243ab074e873007d00, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  bulletPrefab: {fileID: 100204, guid: 2e80d5d9eb66a03468047b0ba2be3928, type: 2}
+  bulletPrefab: {fileID: 162266, guid: 81fd2edb6338185498e473261e181c21, type: 2}
   focusPoint: {x: 0, y: 0, z: 0}
-  NUM_BARRELS: 10
+  target: {fileID: 0}
+  sensorRange: 30
+  fireOnlyWhenPlayerNear: 0
+  NUM_BARRELS: 20
   ORIG_TURRET_RADIUS: 4
+  MAX_SWIVEL: 1.0471976
+  SWIVEL_PERCENTAGE: 0.1
+--- !u!114 &11494766
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 149390}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5d47e790c2d47dc47b3f19befe4cc485, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  bulletPrefab: {fileID: 194514, guid: 83272a788fdf7664c84301dc9014b262, type: 2}
+  focusPoint: {x: 0, y: 0, z: 0}
+  target: {fileID: 0}
+  sensorRange: 30
+  fireOnlyWhenPlayerNear: 0
+  NUM_BARRELS: 20
+  ORIG_TURRET_RADIUS: 10
   MAX_SWIVEL: 1.0471976
   SWIVEL_PERCENTAGE: 0.1
 --- !u!1001 &100100000
@@ -103,7 +127,11 @@ Prefab:
     - target: {fileID: 0}
       propertyPath: bulletPrefab
       value: 
-      objectReference: {fileID: 100204, guid: 2e80d5d9eb66a03468047b0ba2be3928, type: 2}
+      objectReference: {fileID: 194514, guid: 83272a788fdf7664c84301dc9014b262, type: 2}
+    - target: {fileID: 0}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 0}
   m_RootGameObject: {fileID: 149390}

--- a/Assets/Prefabs/LightBullet.prefab
+++ b/Assets/Prefabs/LightBullet.prefab
@@ -93,7 +93,7 @@ Light:
   serializedVersion: 6
   m_Type: 2
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_Intensity: 2
+  m_Intensity: 4
   m_Range: 1
   m_SpotAngle: 30
   m_CookieSize: 10
@@ -284,6 +284,14 @@ Prefab:
     - target: {fileID: 0}
       propertyPath: m_Radius
       value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_Intensity
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_Enabled
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 0}

--- a/Assets/Prefabs/ObjectPooler.prefab
+++ b/Assets/Prefabs/ObjectPooler.prefab
@@ -39,9 +39,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2bd9ee38d27c3c24e9dd792a69435c8c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  pooledObject: {fileID: 100204, guid: 2e80d5d9eb66a03468047b0ba2be3928, type: 2}
+  pooledObject: {fileID: 181106, guid: 0155d5d86cc9a9247973533badd825f4, type: 2}
   pooledAmount: 1000
   willGrow: 1
+  numActiveObj: 0
   pooledObjects: []
 --- !u!1001 &100100000
 Prefab:

--- a/Assets/Prefabs/PointTurret.prefab
+++ b/Assets/Prefabs/PointTurret.prefab
@@ -12,7 +12,6 @@ GameObject:
   - 65: {fileID: 6565420}
   - 23: {fileID: 2313618}
   - 114: {fileID: 11470708}
-  - 114: {fileID: 11432254}
   m_Layer: 0
   m_Name: PointTurret
   m_TagString: Untagged
@@ -27,7 +26,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 199734}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -59.23, y: 0, z: 0}
+  m_LocalPosition: {x: 10.8, y: 21, z: -1.6}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -77,26 +76,13 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
---- !u!114 &11432254
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 199734}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5320bc61a4cf13f4aa535ca7e4e0ce93, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  bulletPrefab: {fileID: 194514, guid: 83272a788fdf7664c84301dc9014b262, type: 2}
-  target: {fileID: 0}
 --- !u!114 &11470708
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 199734}
-  m_Enabled: 0
+  m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 501b36e736bc9b840a7e915f2f8548aa, type: 3}
   m_Name: 

--- a/Assets/Prefabs/PointTurret.prefab
+++ b/Assets/Prefabs/PointTurret.prefab
@@ -12,6 +12,7 @@ GameObject:
   - 65: {fileID: 6565420}
   - 23: {fileID: 2313618}
   - 114: {fileID: 11470708}
+  - 114: {fileID: 11432254}
   m_Layer: 0
   m_Name: PointTurret
   m_TagString: Untagged
@@ -76,13 +77,26 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
---- !u!114 &11470708
+--- !u!114 &11432254
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 199734}
   m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5320bc61a4cf13f4aa535ca7e4e0ce93, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  bulletPrefab: {fileID: 194514, guid: 83272a788fdf7664c84301dc9014b262, type: 2}
+  target: {fileID: 0}
+--- !u!114 &11470708
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 199734}
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 501b36e736bc9b840a7e915f2f8548aa, type: 3}
   m_Name: 
@@ -100,6 +114,10 @@ Prefab:
       propertyPath: bulletPrefab
       value: 
       objectReference: {fileID: 100204, guid: 2e80d5d9eb66a03468047b0ba2be3928, type: 2}
+    - target: {fileID: 0}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 0}
   m_RootGameObject: {fileID: 199734}

--- a/Assets/Prefabs/RakingTurret.prefab
+++ b/Assets/Prefabs/RakingTurret.prefab
@@ -12,6 +12,7 @@ GameObject:
   - 65: {fileID: 6571210}
   - 23: {fileID: 2331856}
   - 114: {fileID: 11428292}
+  - 114: {fileID: 11419094}
   m_Layer: 0
   m_Name: RakingTurret
   m_TagString: Untagged
@@ -26,7 +27,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 158774}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -53.105343, y: 8.621468, z: 11.116618}
+  m_LocalPosition: {x: -66.7, y: 1.3, z: -20.3}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -76,6 +77,27 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &11419094
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 158774}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4623529d3afb2f14baf0f0dd2e216899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  bulletPrefab: {fileID: 194514, guid: 83272a788fdf7664c84301dc9014b262, type: 2}
+  focusPoint: {x: 0, y: 0, z: 0}
+  target: {fileID: 0}
+  sensorRange: 5
+  fireOnlyWhenPlayerNear: 0
+  NUM_BARRELS: 4
+  TURRET_RADIUS: 4
+  MAX_SWIVEL: 1.0471976
+  SWIVEL_PERCENTAGE: 0.1
+  BULLET_SEPARATION: 0
 --- !u!114 &11428292
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -89,11 +111,15 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   bulletPrefab: {fileID: 100204, guid: 2e80d5d9eb66a03468047b0ba2be3928, type: 2}
   focusPoint: {x: 0, y: 0, z: 0}
+  target: {fileID: 0}
+  sensorRange: 30
+  fireOnlyWhenPlayerNear: 0
   NUM_BARRELS: 4
   TURRET_RADIUS: 4
   MAX_SWIVEL: 1.0471976
   SWIVEL_PERCENTAGE: 0.1
   BULLET_SEPARATION: 0
+  ROTATION_ANGLE: {x: 0, y: 0, z: 15}
 --- !u!1001 &100100000
 Prefab:
   m_ObjectHideFlags: 1
@@ -104,7 +130,11 @@ Prefab:
     - target: {fileID: 0}
       propertyPath: bulletPrefab
       value: 
-      objectReference: {fileID: 100204, guid: 2e80d5d9eb66a03468047b0ba2be3928, type: 2}
+      objectReference: {fileID: 194514, guid: 83272a788fdf7664c84301dc9014b262, type: 2}
+    - target: {fileID: 0}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 0}
   m_RootGameObject: {fileID: 158774}

--- a/Assets/Prefabs/RakingTurret.prefab
+++ b/Assets/Prefabs/RakingTurret.prefab
@@ -12,14 +12,13 @@ GameObject:
   - 65: {fileID: 6571210}
   - 23: {fileID: 2331856}
   - 114: {fileID: 11428292}
-  - 114: {fileID: 11419094}
   m_Layer: 0
   m_Name: RakingTurret
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &441152
 Transform:
   m_ObjectHideFlags: 1
@@ -77,27 +76,6 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
---- !u!114 &11419094
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 158774}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4623529d3afb2f14baf0f0dd2e216899, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  bulletPrefab: {fileID: 194514, guid: 83272a788fdf7664c84301dc9014b262, type: 2}
-  focusPoint: {x: 0, y: 0, z: 0}
-  target: {fileID: 0}
-  sensorRange: 5
-  fireOnlyWhenPlayerNear: 0
-  NUM_BARRELS: 4
-  TURRET_RADIUS: 4
-  MAX_SWIVEL: 1.0471976
-  SWIVEL_PERCENTAGE: 0.1
-  BULLET_SEPARATION: 0
 --- !u!114 &11428292
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/SpriteBullet.prefab
+++ b/Assets/Prefabs/SpriteBullet.prefab
@@ -138,7 +138,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bb0a7de91fd123043ad2ada49a57377e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  decal: {fileID: 106938, guid: 7eef142717ab9324f9cdbd816be9677f, type: 2}
   brackets: {fileID: 0}
 --- !u!114 &11459564
 MonoBehaviour:
@@ -315,10 +314,6 @@ Prefab:
       propertyPath: m_TagString
       value: Projectile
       objectReference: {fileID: 0}
-    - target: {fileID: 0}
-      propertyPath: decal
-      value: 
-      objectReference: {fileID: 106938, guid: 7eef142717ab9324f9cdbd816be9677f, type: 2}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 0}
   m_RootGameObject: {fileID: 100204}

--- a/Assets/Prefabs/T-Turret.prefab
+++ b/Assets/Prefabs/T-Turret.prefab
@@ -12,6 +12,7 @@ GameObject:
   - 65: {fileID: 6547246}
   - 23: {fileID: 2333088}
   - 114: {fileID: 11432858}
+  - 114: {fileID: 11491996}
   m_Layer: 0
   m_Name: T-Turret
   m_TagString: Untagged
@@ -82,12 +83,25 @@ MonoBehaviour:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 189552}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9d3fd4ecd8255854982ea5d11da8faae, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   bulletPrefab: {fileID: 100204, guid: 2e80d5d9eb66a03468047b0ba2be3928, type: 2}
+  target: {fileID: 0}
+--- !u!114 &11491996
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 189552}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c2709031a2270614cad663e7d572e6b9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  bulletPrefab: {fileID: 194514, guid: 83272a788fdf7664c84301dc9014b262, type: 2}
   target: {fileID: 0}
 --- !u!1001 &100100000
 Prefab:
@@ -99,7 +113,11 @@ Prefab:
     - target: {fileID: 0}
       propertyPath: bulletPrefab
       value: 
-      objectReference: {fileID: 100204, guid: 2e80d5d9eb66a03468047b0ba2be3928, type: 2}
+      objectReference: {fileID: 194514, guid: 83272a788fdf7664c84301dc9014b262, type: 2}
+    - target: {fileID: 0}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 0}
   m_RootGameObject: {fileID: 189552}

--- a/Assets/Prefabs/T-Turret.prefab
+++ b/Assets/Prefabs/T-Turret.prefab
@@ -26,7 +26,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 189552}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -73.75, y: 0, z: 0}
+  m_LocalPosition: {x: 11.540494, y: 21.9, z: -50.3}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -89,6 +89,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   bulletPrefab: {fileID: 100204, guid: 2e80d5d9eb66a03468047b0ba2be3928, type: 2}
   target: {fileID: 0}
+  BULLET_FREQUENCY: 10
+  BARREL_SEPARATION: 1
+  ROTATION_ANGLE: {x: 0, y: 0, z: 15}
 --- !u!1001 &100100000
 Prefab:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/T-Turret.prefab
+++ b/Assets/Prefabs/T-Turret.prefab
@@ -12,14 +12,13 @@ GameObject:
   - 65: {fileID: 6547246}
   - 23: {fileID: 2333088}
   - 114: {fileID: 11432858}
-  - 114: {fileID: 11491996}
   m_Layer: 0
   m_Name: T-Turret
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &420368
 Transform:
   m_ObjectHideFlags: 1
@@ -27,7 +26,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 189552}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -73.75, y: 0, z: 0}
+  m_LocalPosition: {x: 11.540494, y: 21.9, z: -50.3}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -83,25 +82,12 @@ MonoBehaviour:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 189552}
-  m_Enabled: 0
+  m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9d3fd4ecd8255854982ea5d11da8faae, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   bulletPrefab: {fileID: 100204, guid: 2e80d5d9eb66a03468047b0ba2be3928, type: 2}
-  target: {fileID: 0}
---- !u!114 &11491996
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 189552}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c2709031a2270614cad663e7d572e6b9, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  bulletPrefab: {fileID: 194514, guid: 83272a788fdf7664c84301dc9014b262, type: 2}
   target: {fileID: 0}
 --- !u!1001 &100100000
 Prefab:

--- a/Assets/Prefabs/TriangleTurret_Flat.prefab
+++ b/Assets/Prefabs/TriangleTurret_Flat.prefab
@@ -12,14 +12,13 @@ GameObject:
   - 65: {fileID: 6548270}
   - 23: {fileID: 2321622}
   - 114: {fileID: 11457294}
-  - 114: {fileID: 11482962}
   m_Layer: 0
   m_Name: TriangleTurret_Flat
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &470550
 Transform:
   m_ObjectHideFlags: 1
@@ -89,19 +88,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   bulletPrefab: {fileID: 100204, guid: 2e80d5d9eb66a03468047b0ba2be3928, type: 2}
-  target: {fileID: 0}
---- !u!114 &11482962
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 107580}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9a1de349cd7e74247af49ec1d52f04a5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  bulletPrefab: {fileID: 194514, guid: 83272a788fdf7664c84301dc9014b262, type: 2}
   target: {fileID: 0}
 --- !u!1001 &100100000
 Prefab:

--- a/Assets/Prefabs/TriangleTurret_Flat.prefab
+++ b/Assets/Prefabs/TriangleTurret_Flat.prefab
@@ -26,7 +26,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 107580}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -72.2, y: 0, z: 0}
+  m_LocalPosition: {x: 13.2, y: 19.864044, z: -15.247951}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -89,6 +89,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   bulletPrefab: {fileID: 100204, guid: 2e80d5d9eb66a03468047b0ba2be3928, type: 2}
   target: {fileID: 0}
+  BULLET_FREQUENCY: 7
+  BARREL_SEPARATION: 0.25
+  ROTATION_ANGLE: {x: 0, y: 0, z: 15}
 --- !u!1001 &100100000
 Prefab:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/TriangleTurret_Flat.prefab
+++ b/Assets/Prefabs/TriangleTurret_Flat.prefab
@@ -12,6 +12,7 @@ GameObject:
   - 65: {fileID: 6548270}
   - 23: {fileID: 2321622}
   - 114: {fileID: 11457294}
+  - 114: {fileID: 11482962}
   m_Layer: 0
   m_Name: TriangleTurret_Flat
   m_TagString: Untagged
@@ -26,7 +27,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 107580}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -72.2, y: 0, z: 0}
+  m_LocalPosition: {x: 13.2, y: 19.864044, z: -15.247951}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -89,6 +90,19 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   bulletPrefab: {fileID: 100204, guid: 2e80d5d9eb66a03468047b0ba2be3928, type: 2}
   target: {fileID: 0}
+--- !u!114 &11482962
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 107580}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9a1de349cd7e74247af49ec1d52f04a5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  bulletPrefab: {fileID: 194514, guid: 83272a788fdf7664c84301dc9014b262, type: 2}
+  target: {fileID: 0}
 --- !u!1001 &100100000
 Prefab:
   m_ObjectHideFlags: 1
@@ -99,7 +113,11 @@ Prefab:
     - target: {fileID: 0}
       propertyPath: bulletPrefab
       value: 
-      objectReference: {fileID: 100204, guid: 2e80d5d9eb66a03468047b0ba2be3928, type: 2}
+      objectReference: {fileID: 194514, guid: 83272a788fdf7664c84301dc9014b262, type: 2}
+    - target: {fileID: 0}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 0}
   m_RootGameObject: {fileID: 107580}

--- a/Assets/Prefabs/TriangleTurret_Wall.prefab
+++ b/Assets/Prefabs/TriangleTurret_Wall.prefab
@@ -12,6 +12,7 @@ GameObject:
   - 65: {fileID: 6586482}
   - 23: {fileID: 2370520}
   - 114: {fileID: 11400112}
+  - 114: {fileID: 11488056}
   m_Layer: 0
   m_Name: TriangleTurret_Wall
   m_TagString: Untagged
@@ -26,7 +27,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 106528}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -72.2, y: 0, z: 0}
+  m_LocalPosition: {x: 24.106548, y: 1.2, z: 4.5972013}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -89,6 +90,19 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   bulletPrefab: {fileID: 100204, guid: 2e80d5d9eb66a03468047b0ba2be3928, type: 2}
   target: {fileID: 0}
+--- !u!114 &11488056
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 106528}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 22bb9916f2897904c9afcd5448adcde4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  bulletPrefab: {fileID: 194514, guid: 83272a788fdf7664c84301dc9014b262, type: 2}
+  target: {fileID: 0}
 --- !u!1001 &100100000
 Prefab:
   m_ObjectHideFlags: 1
@@ -99,7 +113,11 @@ Prefab:
     - target: {fileID: 0}
       propertyPath: bulletPrefab
       value: 
-      objectReference: {fileID: 100204, guid: 2e80d5d9eb66a03468047b0ba2be3928, type: 2}
+      objectReference: {fileID: 194514, guid: 83272a788fdf7664c84301dc9014b262, type: 2}
+    - target: {fileID: 0}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 0}
   m_RootGameObject: {fileID: 106528}

--- a/Assets/Prefabs/TriangleTurret_Wall.prefab
+++ b/Assets/Prefabs/TriangleTurret_Wall.prefab
@@ -12,14 +12,13 @@ GameObject:
   - 65: {fileID: 6586482}
   - 23: {fileID: 2370520}
   - 114: {fileID: 11400112}
-  - 114: {fileID: 11488056}
   m_Layer: 0
   m_Name: TriangleTurret_Wall
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &448868
 Transform:
   m_ObjectHideFlags: 1
@@ -90,19 +89,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   bulletPrefab: {fileID: 100204, guid: 2e80d5d9eb66a03468047b0ba2be3928, type: 2}
   target: {fileID: 0}
---- !u!114 &11488056
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 106528}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 22bb9916f2897904c9afcd5448adcde4, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  bulletPrefab: {fileID: 194514, guid: 83272a788fdf7664c84301dc9014b262, type: 2}
-  target: {fileID: 0}
+  ROTATION_ANGLE: {x: 0, y: 0, z: 15}
+  TRIANGLE_HEIGHT: 0
 --- !u!1001 &100100000
 Prefab:
   m_ObjectHideFlags: 1

--- a/Assets/Scenes/BulletTest.unity
+++ b/Assets/Scenes/BulletTest.unity
@@ -122,7 +122,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 22494962, guid: a2ca0d27cf986694ea03f4e39bbfc58c, type: 2}
       propertyPath: m_RootOrder
-      value: 7
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 22494962, guid: a2ca0d27cf986694ea03f4e39bbfc58c, type: 2}
       propertyPath: m_AnchoredPosition.x
@@ -393,7 +393,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 410606, guid: 651bc947edafe5c4f990209597d0068d, type: 2}
       propertyPath: m_RootOrder
-      value: 7
+      value: 5
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 651bc947edafe5c4f990209597d0068d, type: 2}
@@ -446,16 +446,89 @@ Prefab:
       value: FountainTurret (1)
       objectReference: {fileID: 0}
     - target: {fileID: 11494060, guid: dd0a156b16675d9489367bfe6f45c50e, type: 2}
-      propertyPath: bulletVel
-      value: 4
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 11494766, guid: dd0a156b16675d9489367bfe6f45c50e, type: 2}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 11494766, guid: dd0a156b16675d9489367bfe6f45c50e, type: 2}
+      propertyPath: NUM_BARRELS
+      value: 20
       objectReference: {fileID: 0}
     - target: {fileID: 11494060, guid: dd0a156b16675d9489367bfe6f45c50e, type: 2}
-      propertyPath: fireRate
-      value: 2
+      propertyPath: NUM_BARRELS
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 11494060, guid: dd0a156b16675d9489367bfe6f45c50e, type: 2}
+      propertyPath: ORIG_TURRET_RADIUS
+      value: 10
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: dd0a156b16675d9489367bfe6f45c50e, type: 2}
   m_IsPrefabParent: 0
+--- !u!1 &811058247
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 811058250}
+  - 114: {fileID: 811058249}
+  - 114: {fileID: 811058248}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &811058248
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 811058247}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1077351063, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
+--- !u!114 &811058249
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 811058247}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -619905303, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 5
+--- !u!4 &811058250
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 811058247}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 12
 --- !u!1001 &918675042
 Prefab:
   m_ObjectHideFlags: 0
@@ -500,12 +573,28 @@ Prefab:
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 11494060, guid: dd0a156b16675d9489367bfe6f45c50e, type: 2}
-      propertyPath: bulletVel
-      value: 4
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 11494766, guid: dd0a156b16675d9489367bfe6f45c50e, type: 2}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 11494766, guid: dd0a156b16675d9489367bfe6f45c50e, type: 2}
+      propertyPath: NUM_BARRELS
+      value: 20
       objectReference: {fileID: 0}
     - target: {fileID: 11494060, guid: dd0a156b16675d9489367bfe6f45c50e, type: 2}
-      propertyPath: fireRate
-      value: 2
+      propertyPath: NUM_BARRELS
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 11494766, guid: dd0a156b16675d9489367bfe6f45c50e, type: 2}
+      propertyPath: ORIG_TURRET_RADIUS
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 11494060, guid: dd0a156b16675d9489367bfe6f45c50e, type: 2}
+      propertyPath: ORIG_TURRET_RADIUS
+      value: 10
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: dd0a156b16675d9489367bfe6f45c50e, type: 2}
@@ -516,6 +605,91 @@ MonoBehaviour:
     type: 2}
   m_PrefabInternal: {fileID: 1781450704}
   m_Script: {fileID: 11500000, guid: b3d25025a37b1824ab364a7cac2d131c, type: 3}
+--- !u!1 &1107647269
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 224: {fileID: 1107647270}
+  - 222: {fileID: 1107647273}
+  - 114: {fileID: 1107647272}
+  - 114: {fileID: 1107647271}
+  m_Layer: 5
+  m_Name: Bullet Count
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1107647270
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1107647269}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1969677818}
+  m_RootOrder: 0
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -108.9, y: 67.69998}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1107647271
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1107647269}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 177bf015f88e3d842ba3365c702e5754, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1107647272
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1107647269}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 24
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 48
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 0
+--- !u!222 &1107647273
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1107647269}
 --- !u!1001 &1272617110
 Prefab:
   m_ObjectHideFlags: 0
@@ -553,7 +727,15 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 495072, guid: 1a2dd4bc152744e4b9558a0a9e634e34, type: 2}
       propertyPath: m_RootOrder
-      value: 5
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 116698, guid: 1a2dd4bc152744e4b9558a0a9e634e34, type: 2}
+      propertyPath: m_TagString
+      value: Object Pooler
+      objectReference: {fileID: 0}
+    - target: {fileID: 116698, guid: 1a2dd4bc152744e4b9558a0a9e634e34, type: 2}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 1a2dd4bc152744e4b9558a0a9e634e34, type: 2}
@@ -675,6 +857,97 @@ Prefab:
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 84dc57e727400a441a3d866f5caf8f5a, type: 2}
   m_IsPrefabParent: 0
+--- !u!1 &1969677814
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 224: {fileID: 1969677818}
+  - 223: {fileID: 1969677817}
+  - 114: {fileID: 1969677816}
+  - 114: {fileID: 1969677815}
+  m_Layer: 5
+  m_Name: BulletCountCanvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1969677815
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1969677814}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1301386320, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &1969677816
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1969677814}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1980459831, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+--- !u!223 &1969677817
+Canvas:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1969677814}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &1969677818
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1969677814}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_Children:
+  - {fileID: 1107647270}
+  m_Father: {fileID: 0}
+  m_RootOrder: 9
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
 --- !u!1001 &1983193741
 Prefab:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/testScene.unity
+++ b/Assets/Scenes/testScene.unity
@@ -349,18 +349,6 @@ Prefab:
       propertyPath: target
       value: 
       objectReference: {fileID: 1581193771}
-    - target: {fileID: 199734, guid: 27e18262622178d42b3ea2b6975291de, type: 2}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 11470708, guid: 27e18262622178d42b3ea2b6975291de, type: 2}
-      propertyPath: bulletVel
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 11470708, guid: 27e18262622178d42b3ea2b6975291de, type: 2}
-      propertyPath: fireRate
-      value: 10
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 27e18262622178d42b3ea2b6975291de, type: 2}
   m_IsPrefabParent: 0
@@ -468,10 +456,6 @@ Prefab:
       propertyPath: target
       value: 
       objectReference: {fileID: 1581193771}
-    - target: {fileID: 189552, guid: 68ace85d9aa8e544bb9da7273e84e54a, type: 2}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 68ace85d9aa8e544bb9da7273e84e54a, type: 2}
   m_IsPrefabParent: 0
@@ -512,16 +496,12 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 448868, guid: 35b32d704921ee345b64c3faf4bf6930, type: 2}
       propertyPath: m_RootOrder
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 11400112, guid: 35b32d704921ee345b64c3faf4bf6930, type: 2}
       propertyPath: target
       value: 
       objectReference: {fileID: 1581193771}
-    - target: {fileID: 106528, guid: 35b32d704921ee345b64c3faf4bf6930, type: 2}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 35b32d704921ee345b64c3faf4bf6930, type: 2}
   m_IsPrefabParent: 0
@@ -674,14 +654,10 @@ Prefab:
       propertyPath: m_RootOrder
       value: 20
       objectReference: {fileID: 0}
-    - target: {fileID: 149390, guid: dd0a156b16675d9489367bfe6f45c50e, type: 2}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 11494060, guid: dd0a156b16675d9489367bfe6f45c50e, type: 2}
-      propertyPath: bulletPrefab
+      propertyPath: target
       value: 
-      objectReference: {fileID: 162266, guid: 81fd2edb6338185498e473261e181c21, type: 2}
+      objectReference: {fileID: 1581193771}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: dd0a156b16675d9489367bfe6f45c50e, type: 2}
   m_IsPrefabParent: 0
@@ -816,10 +792,10 @@ Prefab:
       propertyPath: m_RootOrder
       value: 18
       objectReference: {fileID: 0}
-    - target: {fileID: 158774, guid: 497fc433dd905ed4ca9113393b35be66, type: 2}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
+    - target: {fileID: 11428292, guid: 497fc433dd905ed4ca9113393b35be66, type: 2}
+      propertyPath: target
+      value: 
+      objectReference: {fileID: 1581193771}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 497fc433dd905ed4ca9113393b35be66, type: 2}
   m_IsPrefabParent: 0
@@ -1168,10 +1144,6 @@ Prefab:
       propertyPath: target
       value: 
       objectReference: {fileID: 1581193771}
-    - target: {fileID: 112256, guid: 122696be4ad65c349a8d9d889aff916a, type: 2}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 122696be4ad65c349a8d9d889aff916a, type: 2}
   m_IsPrefabParent: 0
@@ -1289,20 +1261,12 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 494534, guid: b0cbd55398b99f941bc7c185646b0743, type: 2}
       propertyPath: m_RootOrder
-      value: 17
-      objectReference: {fileID: 0}
-    - target: {fileID: 130172, guid: b0cbd55398b99f941bc7c185646b0743, type: 2}
-      propertyPath: m_IsActive
-      value: 1
+      value: 16
       objectReference: {fileID: 0}
     - target: {fileID: 11443196, guid: b0cbd55398b99f941bc7c185646b0743, type: 2}
-      propertyPath: bulletVel
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 11443196, guid: b0cbd55398b99f941bc7c185646b0743, type: 2}
-      propertyPath: fireRate
-      value: 10
-      objectReference: {fileID: 0}
+      propertyPath: target
+      value: 
+      objectReference: {fileID: 1581193771}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: b0cbd55398b99f941bc7c185646b0743, type: 2}
   m_IsPrefabParent: 0
@@ -1349,9 +1313,9 @@ Prefab:
       propertyPath: target
       value: 
       objectReference: {fileID: 1581193771}
-    - target: {fileID: 107580, guid: 0a1269679b9271d49a7460ebd9a6d16c, type: 2}
-      propertyPath: m_IsActive
-      value: 0
+    - target: {fileID: 11457294, guid: 0a1269679b9271d49a7460ebd9a6d16c, type: 2}
+      propertyPath: BULLET_FREQUENCY
+      value: 7
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 0a1269679b9271d49a7460ebd9a6d16c, type: 2}

--- a/Assets/Scripts/BulletCountDisplay.cs
+++ b/Assets/Scripts/BulletCountDisplay.cs
@@ -1,0 +1,16 @@
+﻿using UnityEngine;
+using UnityEngine.UI;
+using System.Collections;
+
+public class BulletCountDisplay : MonoBehaviour {
+
+	// Use this for initialization
+	void Start () {
+	
+	}
+	
+	// Update is called once per frame
+	void Update () {
+		GetComponent<UnityEngine.UI.Text> ().text = GameObject.FindGameObjectWithTag ("Object Pooler").GetComponent<ObjectPooler> ().numActiveObj.ToString ();
+	}
+}

--- a/Assets/Scripts/BulletCountDisplay.cs.meta
+++ b/Assets/Scripts/BulletCountDisplay.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 177bf015f88e3d842ba3365c702e5754
+timeCreated: 1455242862
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ObjectPooler.cs
+++ b/Assets/Scripts/ObjectPooler.cs
@@ -14,6 +14,7 @@ public class ObjectPooler : MonoBehaviour {
 	public GameObject pooledObject;
 	public int pooledAmount = 100;
 	public bool willGrow = false;
+	public int numActiveObj = 0;
 
 	public List<GameObject> pooledObjects;
 

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -100,7 +100,6 @@ public class PlayerController : MonoBehaviour {
 		// Shooting controls
 		if (im.getInputDown("Shoot") && !isFiring)
 		{
-            //Debug.Log("fire");
 			isFiring = true;
 			InvokeRepeating ("fireBullets", 0.0f, fireRate);
 		}
@@ -304,11 +303,11 @@ public class PlayerController : MonoBehaviour {
 			realBulletVel += GetComponent<Rigidbody> ().velocity;
 		}
 
-		GameObject bulletObj = (GameObject) Instantiate (bulletPrefab, frontOfShip + transform.right, transform.localRotation);
+		GameObject bulletObj = (GameObject) Instantiate (bulletPrefab, frontOfShip + transform.forward + transform.right, transform.localRotation);
 		PlayerBullet newBullet = (PlayerBullet)bulletObj.GetComponent(typeof(PlayerBullet));
 		newBullet.setVars (bulletColor, realBulletVel);
 
-		bulletObj = (GameObject) Instantiate (bulletPrefab, frontOfShip - transform.right, transform.localRotation);
+		bulletObj = (GameObject) Instantiate (bulletPrefab, frontOfShip + transform.forward - transform.right, transform.localRotation);
 		newBullet = (PlayerBullet)bulletObj.GetComponent(typeof(PlayerBullet));
 		newBullet.setVars (bulletColor, realBulletVel);
 	}

--- a/Assets/Scripts/Shield and HUD/RadarTrigger.cs
+++ b/Assets/Scripts/Shield and HUD/RadarTrigger.cs
@@ -37,6 +37,7 @@ public class RadarTrigger : MonoBehaviour {
 	void OnTriggerExit(Collider other) {
 		if (other.gameObject.CompareTag ("Projectile")) {
 			radar.RemoveBlip (other.gameObject);
+			//other.GetComponent<LightBulletController> ().brackets.enabled = false;
 			other.GetComponent<Bullet> ().brackets.enabled = false;
 		}
 	}

--- a/Assets/Scripts/Turrets/AlgorithmicTurret.cs
+++ b/Assets/Scripts/Turrets/AlgorithmicTurret.cs
@@ -14,6 +14,9 @@ using System.Collections;
 public class AlgorithmicTurret : Turret {
 
 	public Vector3 focusPoint;
+	public GameObject target;
+	public float sensorRange = 30f;
+	public bool fireOnlyWhenPlayerNear = true;
 
 	// Use this for initialization
 	void Start () {

--- a/Assets/Scripts/Turrets/AlgorithmicTurret.cs
+++ b/Assets/Scripts/Turrets/AlgorithmicTurret.cs
@@ -14,12 +14,15 @@ using System.Collections;
 public class AlgorithmicTurret : Turret {
 
 	public Vector3 focusPoint;
+	public GameObject target;
+	public float sensorRange = 30f;
+	public bool fireOnlyWhenPlayerNear = true;
 
 	// Use this for initialization
 	void Start () {
 		focusPoint = transform.position + transform.forward;
 	}
-	
+
 	// Update is called once per frame
 	void Update () {
 		transform.LookAt (focusPoint);

--- a/Assets/Scripts/Turrets/ArcTurret.cs
+++ b/Assets/Scripts/Turrets/ArcTurret.cs
@@ -14,11 +14,11 @@ using System.Collections;
 
 public class ArcTurret : SimpleTurret {
 
-	private float RELATIVE_SPAWNPOINT_MULTIPLIER = 1.5f;
-	private float SEPARATION_ANGLE = Mathf.PI/12;
+	public float RELATIVE_SPAWNPOINT_MULTIPLIER = 1.5f;
+	public float SEPARATION_ANGLE = Mathf.PI/12;
 
 	// Z-component must be a factor of 360
-	private Vector3 ROTATION_ANGLE = new Vector3 (0f, 0f, 15f);
+	public Vector3 ROTATION_ANGLE = new Vector3 (0f, 0f, 15f);
 	private int numFire = 0;
 	private float distFromCenter;
 
@@ -28,7 +28,7 @@ public class ArcTurret : SimpleTurret {
 
 		bulletVel = Velocity.High;
 		bulletColor = Color.green;
-		fireRate = RateOfFire.Extreme;
+		fireRate = RateOfFire.Medium;
 		barrelList = new TurretBarrel[5];
 		//leftmost
 		barrelList [0] = new TurretBarrel ((float)bulletPrefab.GetComponent<Renderer>().bounds.size.x * RELATIVE_SPAWNPOINT_MULTIPLIER,

--- a/Assets/Scripts/Turrets/ArcTurretLight.cs
+++ b/Assets/Scripts/Turrets/ArcTurretLight.cs
@@ -1,15 +1,144 @@
-﻿using UnityEngine;
+﻿/*
+ * ArcTurret.cs
+ * 
+ * Defines members specific to ArcTurret child of SimpleTurret:
+ * - Fires five bullets in arc toward player
+ * - High velocity bullets
+ * - Medium rate of fire
+ * - No acceleration
+ * - Green bullets
+ */
+
+using UnityEngine;
 using System.Collections;
 
-public class ArcTurretLight : MonoBehaviour {
+public class ArcTurretLight : SimpleTurret {
+
+	private float RELATIVE_SPAWNPOINT_MULTIPLIER = 1.5f;
+	private float SEPARATION_ANGLE = Mathf.PI/12;
+
+	// Z-component must be a factor of 360
+	private Vector3 ROTATION_ANGLE = new Vector3 (0f, 0f, 15f);
+	private int numFire = 0;
+	private float distFromCenter;
 
 	// Use this for initialization
 	void Start () {
-	
+		distFromCenter = gameObject.GetComponent<Renderer> ().bounds.size.z;
+
+		bulletVel = Velocity.High;
+		bulletColor = Color.green;
+		fireRate = RateOfFire.Extreme;
+		barrelList = new TurretBarrel[5];
+		//leftmost
+		barrelList [0] = new TurretBarrel ((float)bulletPrefab.GetComponent<Light>().range * RELATIVE_SPAWNPOINT_MULTIPLIER,
+			(int)bulletVel);
+		//center-left
+		barrelList [1] = new TurretBarrel ((float)bulletPrefab.GetComponent<Light>().range * RELATIVE_SPAWNPOINT_MULTIPLIER,
+			(int)bulletVel);
+		//center
+		barrelList [2] = new TurretBarrel ((float)bulletPrefab.GetComponent<Light>().range * RELATIVE_SPAWNPOINT_MULTIPLIER,
+			(int)bulletVel);
+		//center-right
+		barrelList [3] = new TurretBarrel ((float)bulletPrefab.GetComponent<Light>().range * RELATIVE_SPAWNPOINT_MULTIPLIER,
+			(int)bulletVel);
+		//leftmost
+		barrelList [4] = new TurretBarrel ((float)bulletPrefab.GetComponent<Light>().range * RELATIVE_SPAWNPOINT_MULTIPLIER,
+			(int)bulletVel);
 	}
-	
+
 	// Update is called once per frame
 	void Update () {
-	
+		var distance = Vector3.Distance (gameObject.transform.position, target.transform.position);
+		//if the player is within the turret's range of sight, target the player and fire
+		if (distance < sensorRange) {
+			gameObject.transform.LookAt (target.transform);
+
+			//give appropriate rotation for the number of times the turret has fired
+			transform.Rotate (ROTATION_ANGLE * numFire);
+
+			//find new point at end of turret once required to target player
+			Vector3 forwardNorm = gameObject.transform.forward;
+			forwardNorm.Normalize ();
+			endOfTurret = gameObject.GetComponent<Renderer> ().bounds.center + (forwardNorm * distFromCenter);
+			//if not firing, start firing
+			if (!isFiring) {
+				isFiring = true;
+				InvokeRepeating ("Fire", (float)fireDelay, (float)fireRate * fireRateMultiplier);
+			}
+		}
+		//if the player is not within range, but the turret is firing, stop firing
+		else if (isFiring) {
+			isFiring = false;
+			CancelInvoke ("Fire");
+		}
+	}
+
+	/*
+	 * Description: Shoots five bullets with ArcTurrets specs
+	 * Post: A bullet has been fired from all TurretBarrels
+	 */
+	protected void Fire () {
+		Vector3 turretCenter = gameObject.GetComponent<Renderer> ().bounds.center;
+		Vector3 aimDirNorm = gameObject.transform.forward;
+		Vector3 leftNorm = gameObject.transform.right * -1;
+		Vector3 rightNorm = gameObject.transform.right;
+		aimDirNorm.Normalize ();
+		leftNorm.Normalize ();
+		rightNorm.Normalize ();
+
+		DetermineBullet (turretCenter, aimDirNorm, leftNorm, rightNorm, 0);
+		DetermineBullet (turretCenter, aimDirNorm, leftNorm, rightNorm, 1);
+		DetermineBullet (turretCenter, aimDirNorm, leftNorm, rightNorm, 2);
+		DetermineBullet (turretCenter, aimDirNorm, leftNorm, rightNorm, 3);
+		DetermineBullet (turretCenter, aimDirNorm, leftNorm, rightNorm, 4);
+
+		//if the turret has made a complete rotation, reset the number of times it has been fired
+		if (numFire == 360 / ROTATION_ANGLE.z)
+			numFire = 1;
+		//else increase the number of times the turret has been fired
+		else
+			++numFire;
+	}
+
+	/*
+	 * Post: A bullet has been created and fired out of one of TurretBarrels 0 through 4 in the proper direction and with the proper velocity
+	 * Arguments:
+	 * - turrCenter: The center of the ArcTurret GameObject
+	 * - aimDirNormMid: The normalized vector denoting the direction in which the middle bullet is to be aimed
+	 * - leftNorm: The normalized vector denoting the direction directly leftward from the ArcTurret GameObject
+	 * - rightNorm: The normalized vector denoting the direction directly rightward from the ArcTurret GameObject
+	 * - bulletNum: The number denoting which of TurretBarrels 0 through 4 is creating a bullet
+	 */
+	private void DetermineBullet (Vector3 turrCenter, Vector3 aimDirNormMid, Vector3 leftNorm, Vector3 rightNorm, int bulletNum) {
+		Vector3 newAimDirNorm = Vector3.zero;
+		GameObject bulletObj = null;
+		bool debugBool = false;
+
+		switch (bulletNum) {
+		case 0:
+			newAimDirNorm = Vector3.RotateTowards (aimDirNormMid, leftNorm, SEPARATION_ANGLE * 2, 0f);
+			CreateBullet (Vector3.RotateTowards (endOfTurret - turrCenter, leftNorm, SEPARATION_ANGLE*2, 0f) + turrCenter + (newAimDirNorm * (barrelList [0].relativeSpawnPoint)), newAimDirNorm);
+			break;
+		case 1:
+			newAimDirNorm = Vector3.RotateTowards (aimDirNormMid, leftNorm, SEPARATION_ANGLE, 0f);
+			CreateBullet (Vector3.RotateTowards (endOfTurret - turrCenter, leftNorm, SEPARATION_ANGLE, 0f) + turrCenter + (newAimDirNorm * (barrelList [1].relativeSpawnPoint)), newAimDirNorm);
+			break;
+		case 2:
+			newAimDirNorm = aimDirNormMid;
+			CreateBullet (endOfTurret + (newAimDirNorm * (barrelList [2].relativeSpawnPoint)), newAimDirNorm);
+			break;
+		case 3:
+			newAimDirNorm = Vector3.RotateTowards (aimDirNormMid, rightNorm, SEPARATION_ANGLE, 0f);
+			CreateBullet (Vector3.RotateTowards (endOfTurret - turrCenter, rightNorm, SEPARATION_ANGLE, 0f) + turrCenter + (newAimDirNorm * (barrelList [3].relativeSpawnPoint)), newAimDirNorm);
+			break;
+		case 4:
+			newAimDirNorm = Vector3.RotateTowards (aimDirNormMid, rightNorm, SEPARATION_ANGLE*2, 0f);
+			CreateBullet (Vector3.RotateTowards (endOfTurret - turrCenter, rightNorm, SEPARATION_ANGLE*2, 0f) + turrCenter + (newAimDirNorm * (barrelList [4].relativeSpawnPoint)), newAimDirNorm);
+			break;
+		default:
+			debugBool = true;
+			break;
+		}
 	}
 }

--- a/Assets/Scripts/Turrets/Bullet.cs
+++ b/Assets/Scripts/Turrets/Bullet.cs
@@ -15,9 +15,7 @@ public class Bullet : MonoBehaviour {
 	//private Vector3 velocity;
 
     private int absorbValue;
-    private Color spriteColor;
 
-    public GameObject decal;
     public Image brackets;
 
 	// Use this for initialization
@@ -35,27 +33,19 @@ public class Bullet : MonoBehaviour {
 	 * post: color and velocity of bullet are set
 	 */
     public void setVars (Color bColor, Vector3 newVel) {
-		gameObject.GetComponent<Renderer> ().material.color = spriteColor = bColor;
+		gameObject.GetComponent<Renderer> ().material.color = bColor;
         gameObject.GetComponent<Rigidbody> ().velocity = newVel;
 
     }
 
     void OnCollisionEnter (Collision hit) {
-        PlayerController hitScript = hit.gameObject.GetComponentInParent<PlayerController>();
-        if (hit.gameObject.CompareTag("Player")) {
-            hit.collider.gameObject.GetComponent<CollisionHitDetector>().updateIndicators();
-            if (!hitScript.isShielded())
-            {
-                hitScript.takeDamage();
-            }
-            else
-            {
-               GameObject temp = (GameObject) Instantiate(decal, hit.contacts[0].point, Quaternion.FromToRotation(Vector3.up, hit.contacts[0].normal));
-               temp.GetComponent<ShieldDecalController>().setColor(spriteColor);
-                temp.transform.parent = hit.gameObject.transform;
-            }
-        }
-        Destroy();
+        PlayerController hitScript = hit.gameObject.GetComponent<PlayerController>();
+        if (hit.gameObject.CompareTag("Player") && !hitScript.isShielded()) {
+            hitScript.takeDamage();
+		}
+        //Destroy (gameObject);
+		Destroy();
+		//gameObject.SetActive(false);
 	}
 
     void OnTriggerEnter(Collider volume)
@@ -81,7 +71,8 @@ public class Bullet : MonoBehaviour {
     }
 
 	void OnEnable() {
-		Invoke ("Destroy", 10f);
+		Invoke ("Destroy", 20f);
+		//GameObject.FindGameObjectWithTag ("Object Pooler").GetComponent<ObjectPooler> ().numActiveObj++;
 	}
 
 	public void Destroy() {
@@ -100,5 +91,6 @@ public class Bullet : MonoBehaviour {
 
 	void OnDisable() {
 		CancelInvoke ();
+		//GameObject.FindGameObjectWithTag ("Object Pooler").GetComponent<ObjectPooler> ().numActiveObj--;
 	}
 }

--- a/Assets/Scripts/Turrets/DoubleHelixLight.cs
+++ b/Assets/Scripts/Turrets/DoubleHelixLight.cs
@@ -1,15 +1,73 @@
-﻿using UnityEngine;
+﻿/*
+ * DoubleHelixTurret.cs
+ * 
+ * Defines members specific to DoubleHelixTurret child of AlgorithmicTurret:
+ * - Fires two bullets from opposite ends of a diameter as the turret
+ *   rotates, forming a double helix
+ * - Low velocity bullets
+ * - Extremely high rate of fire
+ * - No acceleration
+ * - Red bullets
+ */
+
+using UnityEngine;
 using System.Collections;
 
-public class DoubleHelixLight : MonoBehaviour {
+public class DoubleHelixLight : AlgorithmicTurret {
+
+	private float BARREL_SEPARATION = 4f;
+
+	// Z-component must be a factor of 360
+	private Vector3 ROTATION_ANGLE = new Vector3 (0f, 0f, 15f);
+
+	public Vector3 bulletPosition;
 
 	// Use this for initialization
 	void Start () {
-	
+		bulletVel = Velocity.Low;
+		bulletColor = Color.red;
+		fireRate = RateOfFire.Extreme;
+		barrelList = new TurretBarrel[2];
+		Vector3 forwardNorm = transform.forward;
+		forwardNorm.Normalize ();
+		endOfTurret = gameObject.GetComponent<Renderer> ().bounds.center + (forwardNorm * gameObject.GetComponent<Renderer> ().bounds.extents.z);
+
+		//left
+		barrelList [0] = new TurretBarrel ((float)bulletPrefab.GetComponent<Light>().range, 
+			(int)bulletVel);
+		//right
+		barrelList [1] = new TurretBarrel ((float)bulletPrefab.GetComponent<Light>().range, 
+			(int)bulletVel);
 	}
-	
+
 	// Update is called once per frame
 	void Update () {
-	
+
+		Vector3 forwardNorm = transform.forward;
+		forwardNorm.Normalize ();
+		endOfTurret = gameObject.GetComponent<Renderer> ().bounds.center + (forwardNorm * gameObject.GetComponent<Renderer> ().bounds.extents.z);
+
+		//if not firing, start firing
+		if (!isFiring) {
+			isFiring = true;
+			InvokeRepeating ("fire", (float)fireDelay, (float)fireRate * fireRateMultiplier);
+		}
+	}
+
+	/*
+	 * Description: Shoots two bullets in straight, parallel lines
+	 * Post: A bullet has been fired from both TurretBarrels
+	 */
+	protected void fire() {
+		Vector3 aimDirNorm = transform.forward;
+		aimDirNorm.Normalize ();
+		Vector3 rightNorm = transform.right;
+		rightNorm.Normalize ();
+
+		CreateBullet (endOfTurret + (-1 * rightNorm * BARREL_SEPARATION / 2) + (aimDirNorm * (barrelList [0].relativeSpawnPoint)), aimDirNorm);
+		CreateBullet (endOfTurret + (rightNorm * BARREL_SEPARATION / 2) + (aimDirNorm * (barrelList [1].relativeSpawnPoint)), aimDirNorm);
+
+		//rotate the turret by the given angle
+		transform.Rotate (ROTATION_ANGLE);
 	}
 }

--- a/Assets/Scripts/Turrets/DoubleHelixTurret.cs
+++ b/Assets/Scripts/Turrets/DoubleHelixTurret.cs
@@ -15,18 +15,18 @@ using System.Collections;
 
 public class DoubleHelixTurret : AlgorithmicTurret {
 
-	public float BARREL_SEPARATION = 10f;
+	public float BARREL_SEPARATION = 4f;
 
 	// Z-component must be a factor of 360
-	private Vector3 ROTATION_ANGLE = new Vector3 (0f, 0f, 15f);
+	public Vector3 ROTATION_ANGLE = new Vector3 (0f, 0f, 15f);
 
 	public Vector3 bulletPosition;
 
 	// Use this for initialization
 	void Start () {
-		//bulletVel = Velocity.Extreme;
+		bulletVel = Velocity.Low;
 		bulletColor = Color.red;
-		//fireRate = RateOfFire.High;
+		fireRate = RateOfFire.Extreme;
 		barrelList = new TurretBarrel[2];
 		Vector3 forwardNorm = transform.forward;
 		forwardNorm.Normalize ();
@@ -34,23 +34,28 @@ public class DoubleHelixTurret : AlgorithmicTurret {
 
 		//left
 		barrelList [0] = new TurretBarrel ((float)bulletPrefab.GetComponent<Renderer>().bounds.size.x, 
-											(int)bulletVel);
+			(int)bulletVel);
 		//right
 		barrelList [1] = new TurretBarrel ((float)bulletPrefab.GetComponent<Renderer>().bounds.size.x, 
-											(int)bulletVel);
+			(int)bulletVel);
 	}
-	
+
 	// Update is called once per frame
 	void Update () {
+		var distance = Vector3.Distance (gameObject.transform.position, target.transform.position);
+		if (distance < sensorRange || !fireOnlyWhenPlayerNear) {
+			Vector3 forwardNorm = transform.forward;
+			forwardNorm.Normalize ();
+			endOfTurret = gameObject.GetComponent<Renderer> ().bounds.center + (forwardNorm * gameObject.GetComponent<Renderer> ().bounds.extents.z);
 
-		Vector3 forwardNorm = transform.forward;
-		forwardNorm.Normalize ();
-		endOfTurret = gameObject.GetComponent<Renderer> ().bounds.center + (forwardNorm * gameObject.GetComponent<Renderer> ().bounds.extents.z);
-
-		//if not firing, start firing
-		if (!isFiring) {
-			isFiring = true;
-			InvokeRepeating ("fire", (float)fireDelay, (float)fireRate * fireRateMultiplier);
+			//if not firing, start firing
+			if (!isFiring) {
+				isFiring = true;
+				InvokeRepeating ("fire", (float)fireDelay, (float)fireRate * fireRateMultiplier);
+			}
+		} else if (fireOnlyWhenPlayerNear && isFiring) {
+			CancelInvoke ("fire");
+			isFiring = false;
 		}
 	}
 

--- a/Assets/Scripts/Turrets/DoubleHelixTurret.cs
+++ b/Assets/Scripts/Turrets/DoubleHelixTurret.cs
@@ -15,18 +15,18 @@ using System.Collections;
 
 public class DoubleHelixTurret : AlgorithmicTurret {
 
-	public float BARREL_SEPARATION = 10f;
+	public float BARREL_SEPARATION = 4f;
 
 	// Z-component must be a factor of 360
-	private Vector3 ROTATION_ANGLE = new Vector3 (0f, 0f, 15f);
+	public Vector3 ROTATION_ANGLE = new Vector3 (0f, 0f, 15f);
 
 	public Vector3 bulletPosition;
 
 	// Use this for initialization
 	void Start () {
-		//bulletVel = Velocity.Extreme;
+		bulletVel = Velocity.Low;
 		bulletColor = Color.red;
-		//fireRate = RateOfFire.High;
+		fireRate = RateOfFire.Extreme;
 		barrelList = new TurretBarrel[2];
 		Vector3 forwardNorm = transform.forward;
 		forwardNorm.Normalize ();
@@ -42,15 +42,20 @@ public class DoubleHelixTurret : AlgorithmicTurret {
 	
 	// Update is called once per frame
 	void Update () {
+		var distance = Vector3.Distance (gameObject.transform.position, target.transform.position);
+		if (distance < sensorRange || !fireOnlyWhenPlayerNear) {
+			Vector3 forwardNorm = transform.forward;
+			forwardNorm.Normalize ();
+			endOfTurret = gameObject.GetComponent<Renderer> ().bounds.center + (forwardNorm * gameObject.GetComponent<Renderer> ().bounds.extents.z);
 
-		Vector3 forwardNorm = transform.forward;
-		forwardNorm.Normalize ();
-		endOfTurret = gameObject.GetComponent<Renderer> ().bounds.center + (forwardNorm * gameObject.GetComponent<Renderer> ().bounds.extents.z);
-
-		//if not firing, start firing
-		if (!isFiring) {
-			isFiring = true;
-			InvokeRepeating ("fire", (float)fireDelay, (float)fireRate * fireRateMultiplier);
+			//if not firing, start firing
+			if (!isFiring) {
+				isFiring = true;
+				InvokeRepeating ("fire", (float)fireDelay, (float)fireRate * fireRateMultiplier);
+			}
+		} else if (fireOnlyWhenPlayerNear && isFiring) {
+			CancelInvoke ("fire");
+			isFiring = false;
 		}
 	}
 

--- a/Assets/Scripts/Turrets/FountainLight.cs
+++ b/Assets/Scripts/Turrets/FountainLight.cs
@@ -1,15 +1,108 @@
-﻿using UnityEngine;
+﻿/*
+ * FountainTurret.cs
+ * 
+ * Defines members specific to FountainTurret child of AlgorithmicTurret:
+ * - Fires a variable number of bullets from opposite ends of variable/2
+ *   diameter
+ * - TurretBarrels swivel inward toward and outward from the center of the
+ *   turret as they shoot
+ * - Low velocity bullets
+ * - High rate of fire
+ * - No acceleration
+ * - Orange bullets
+ */
+
+using UnityEngine;
 using System.Collections;
 
-public class FountainLight : MonoBehaviour {
+public class FountainLight : AlgorithmicTurret {
+	public int NUM_BARRELS = 4;
+	public float ORIG_TURRET_RADIUS = 4;
+	public float MAX_SWIVEL = Mathf.PI/3;
+	public float SWIVEL_PERCENTAGE = 0.1f;
+
+	private float curTurretRadius;
+	private int numFire = 0;
+	private bool rotatingOut = true;
+	private Vector3 ROTATION_ANGLE = new Vector3 (0f, 0f, 15f);
 
 	// Use this for initialization
 	void Start () {
-	
+		bulletVel = Velocity.Low;
+		//orange
+		bulletColor = new Color(1f, 0.6f, 0f, 1f);
+		fireRate = RateOfFire.High;
+		barrelList = new TurretBarrel[NUM_BARRELS];
+
+		Vector3 forwardNorm = transform.forward;
+		forwardNorm.Normalize ();
+		endOfTurret = gameObject.GetComponent<Renderer> ().bounds.center + (forwardNorm * gameObject.GetComponent<Renderer> ().bounds.extents.z);
+
+		curTurretRadius = ORIG_TURRET_RADIUS;
+
+		for (int numBarrel = 0; numBarrel < NUM_BARRELS; ++numBarrel) {
+			barrelList[numBarrel] = new TurretBarrel ((float)bulletPrefab.GetComponent<Light>().range, 
+				(int)bulletVel);
+		}
 	}
-	
+
 	// Update is called once per frame
 	void Update () {
-	
+		Vector3 forwardNorm = transform.forward;
+		forwardNorm.Normalize ();
+		endOfTurret = gameObject.GetComponent<Renderer> ().bounds.center + (forwardNorm * gameObject.GetComponent<Renderer> ().bounds.extents.z);
+
+		//if not firing, start firing
+		if (!isFiring) {
+			isFiring = true;
+			InvokeRepeating ("fire", (float)fireDelay, (float)fireRate * fireRateMultiplier);
+		}
+
+		float distBtwnPlayer = Vector3.Distance(GameObject.Find("Player").transform.position, transform.position);
+
+		if (distBtwnPlayer < 10f) {
+			float percMaxRad = distBtwnPlayer / 10;
+			curTurretRadius = Mathf.Max (percMaxRad * ORIG_TURRET_RADIUS, 2f);
+		} else {
+			curTurretRadius = ORIG_TURRET_RADIUS;
+		}
+	}
+
+	/*
+	 * Description: Shoots bullets equally distributed around the turret while the barrels swivel away from and back toward the center
+	 * Post: A bullet has been fired from all TurretBarrels at an angle determined by MAX_SWIVEL and SWIVEL_PERCENTAGE
+	 */
+	protected void fire() {
+		Vector3 aimDirNorm = transform.forward;
+		aimDirNorm.Normalize ();
+		Vector3 rightNorm = transform.right;
+		rightNorm.Normalize ();
+		Vector3 upNorm = transform.up;
+		upNorm.Normalize ();
+
+		GameObject bulletObj;
+		Bullet newBullet;
+		Vector3 bulletPosition = upNorm * curTurretRadius;
+		aimDirNorm = Vector3.RotateTowards (aimDirNorm, upNorm, MAX_SWIVEL * SWIVEL_PERCENTAGE * numFire, 0f);
+
+		for (int numBarrel = 0; numBarrel < NUM_BARRELS; ++numBarrel) {
+			Quaternion rotQuat = Quaternion.AngleAxis (360f / NUM_BARRELS * numBarrel, transform.forward);
+			CreateBullet (endOfTurret + rotQuat * bulletPosition, rotQuat * aimDirNorm);
+		}
+
+		if (rotatingOut) {
+			++numFire;
+			if (numFire + 1 > 1 / SWIVEL_PERCENTAGE) {
+				rotatingOut = false;
+			}
+		} else {
+			--numFire;
+			if (numFire == 0) {
+				rotatingOut = true;
+			}
+		}
+
+		//rotate the turret by the given angle
+		//transform.Rotate (ROTATION_ANGLE);
 	}
 }

--- a/Assets/Scripts/Turrets/FountainTurret.cs
+++ b/Assets/Scripts/Turrets/FountainTurret.cs
@@ -24,14 +24,14 @@ public class FountainTurret : AlgorithmicTurret {
 	private float curTurretRadius;
 	private int numFire = 0;
 	private bool rotatingOut = true;
-	private Vector3 ROTATION_ANGLE = new Vector3 (0f, 0f, 15f);
+	public Vector3 ROTATION_ANGLE = new Vector3 (0f, 0f, 15f);
 
 	// Use this for initialization
 	void Start () {
-		//bulletVel = Velocity.Low;
+		bulletVel = Velocity.Medium;
 		//orange
 		bulletColor = new Color(1f, 0.6f, 0f, 1f);
-		//fireRate = RateOfFire.High;
+		fireRate = RateOfFire.Medium;
 		barrelList = new TurretBarrel[NUM_BARRELS];
 
 		Vector3 forwardNorm = transform.forward;
@@ -42,29 +42,35 @@ public class FountainTurret : AlgorithmicTurret {
 
 		for (int numBarrel = 0; numBarrel < NUM_BARRELS; ++numBarrel) {
 			barrelList[numBarrel] = new TurretBarrel ((float)bulletPrefab.GetComponent<Renderer>().bounds.size.x, 
-														(int)bulletVel);
+				(int)bulletVel);
 		}
 	}
-	
+
 	// Update is called once per frame
 	void Update () {
-		Vector3 forwardNorm = transform.forward;
-		forwardNorm.Normalize ();
-		endOfTurret = gameObject.GetComponent<Renderer> ().bounds.center + (forwardNorm * gameObject.GetComponent<Renderer> ().bounds.extents.z);
+		var distance = Vector3.Distance (gameObject.transform.position, target.transform.position);
+		if (distance < sensorRange || !fireOnlyWhenPlayerNear) {
+			Vector3 forwardNorm = transform.forward;
+			forwardNorm.Normalize ();
+			endOfTurret = gameObject.GetComponent<Renderer> ().bounds.center + (forwardNorm * gameObject.GetComponent<Renderer> ().bounds.extents.z);
 
-		//if not firing, start firing
-		if (!isFiring) {
-			isFiring = true;
-			InvokeRepeating ("fire", (float)fireDelay, (float)fireRate * fireRateMultiplier);
-		}
+			//if not firing, start firing
+			if (!isFiring) {
+				isFiring = true;
+				InvokeRepeating ("fire", (float)fireDelay, (float)fireRate * fireRateMultiplier);
+			}
 
-		float distBtwnPlayer = Vector3.Distance(GameObject.Find("Player").transform.position, transform.position);
+			float distBtwnPlayer = Vector3.Distance(GameObject.Find("Player").transform.position, transform.position);
 
-		if (distBtwnPlayer < 10f) {
-			float percMaxRad = distBtwnPlayer / 10;
-			curTurretRadius = Mathf.Max (percMaxRad * ORIG_TURRET_RADIUS, 2f);
-		} else {
-			curTurretRadius = ORIG_TURRET_RADIUS;
+			if (distBtwnPlayer < 10f) {
+				float percMaxRad = distBtwnPlayer / 10;
+				curTurretRadius = Mathf.Max (percMaxRad * ORIG_TURRET_RADIUS, 2f);
+			} else {
+				curTurretRadius = ORIG_TURRET_RADIUS;
+			}
+		} else if (fireOnlyWhenPlayerNear && isFiring) {
+			CancelInvoke ("fire");
+			isFiring = false;
 		}
 	}
 

--- a/Assets/Scripts/Turrets/FountainTurret.cs
+++ b/Assets/Scripts/Turrets/FountainTurret.cs
@@ -28,10 +28,10 @@ public class FountainTurret : AlgorithmicTurret {
 
 	// Use this for initialization
 	void Start () {
-		//bulletVel = Velocity.Low;
+		bulletVel = Velocity.Medium;
 		//orange
 		bulletColor = new Color(1f, 0.6f, 0f, 1f);
-		//fireRate = RateOfFire.High;
+		fireRate = RateOfFire.Medium;
 		barrelList = new TurretBarrel[NUM_BARRELS];
 
 		Vector3 forwardNorm = transform.forward;
@@ -48,23 +48,29 @@ public class FountainTurret : AlgorithmicTurret {
 	
 	// Update is called once per frame
 	void Update () {
-		Vector3 forwardNorm = transform.forward;
-		forwardNorm.Normalize ();
-		endOfTurret = gameObject.GetComponent<Renderer> ().bounds.center + (forwardNorm * gameObject.GetComponent<Renderer> ().bounds.extents.z);
+		var distance = Vector3.Distance (gameObject.transform.position, target.transform.position);
+		if (distance < sensorRange || !fireOnlyWhenPlayerNear) {
+			Vector3 forwardNorm = transform.forward;
+			forwardNorm.Normalize ();
+			endOfTurret = gameObject.GetComponent<Renderer> ().bounds.center + (forwardNorm * gameObject.GetComponent<Renderer> ().bounds.extents.z);
 
-		//if not firing, start firing
-		if (!isFiring) {
-			isFiring = true;
-			InvokeRepeating ("fire", (float)fireDelay, (float)fireRate * fireRateMultiplier);
-		}
+			//if not firing, start firing
+			if (!isFiring) {
+				isFiring = true;
+				InvokeRepeating ("fire", (float)fireDelay, (float)fireRate * fireRateMultiplier);
+			}
 
-		float distBtwnPlayer = Vector3.Distance(GameObject.Find("Player").transform.position, transform.position);
+			float distBtwnPlayer = Vector3.Distance(GameObject.Find("Player").transform.position, transform.position);
 
-		if (distBtwnPlayer < 10f) {
-			float percMaxRad = distBtwnPlayer / 10;
-			curTurretRadius = Mathf.Max (percMaxRad * ORIG_TURRET_RADIUS, 2f);
-		} else {
-			curTurretRadius = ORIG_TURRET_RADIUS;
+			if (distBtwnPlayer < 10f) {
+				float percMaxRad = distBtwnPlayer / 10;
+				curTurretRadius = Mathf.Max (percMaxRad * ORIG_TURRET_RADIUS, 2f);
+			} else {
+				curTurretRadius = ORIG_TURRET_RADIUS;
+			}
+		} else if (fireOnlyWhenPlayerNear && isFiring) {
+			CancelInvoke ("fire");
+			isFiring = false;
 		}
 	}
 

--- a/Assets/Scripts/Turrets/LightBulletController.cs
+++ b/Assets/Scripts/Turrets/LightBulletController.cs
@@ -10,120 +10,85 @@ using UnityEngine;
 using UnityEngine.UI;
 using System.Collections;
 
-public class LightBulletController : MonoBehaviour
-{
+public class LightBulletController : MonoBehaviour {
 
-    //private Vector3 velocity;
+	//private Vector3 velocity;
 
-    private int absorbValue;
+	private int absorbValue;
 
-    public Image brackets;
-    private ThreatTriggerController[] cachedTrigger; // can store up to all 4 quadrants behind the player if need be
+	public Image brackets;
 
-    // Use this for initialization
-    void Awake()
-    {
-        brackets = GetComponentInChildren<Image>();
-        absorbValue = 1;
-        cachedTrigger = new ThreatTriggerController[4];
-    }
+	// Use this for initialization
+	void Awake () {
+		brackets = GetComponentInChildren<Image>();
+		absorbValue = 1;
+	}
 
-    // Update is called once per frame
-    void Update()
-    {
-    }
+	// Update is called once per frame
+	void Update () {
+	}
 
-    /*
+	/*
 	 * Description: Sets values for empty vars
 	 * post: color and velocity of bullet are set
 	 */
-    public void setVars(Color bColor, Vector3 newVel)
-    {
-        gameObject.GetComponent<Light>().color = bColor;
-        gameObject.GetComponent<Rigidbody>().velocity = newVel;
+	public void setVars (Color bColor, Vector3 newVel) {
+		gameObject.GetComponent<Light> ().color = bColor;
+		gameObject.GetComponent<Rigidbody> ().velocity = newVel;
 
-    }
+	}
 
-    void OnCollisionEnter(Collision hit)
-    {
-        PlayerController hitScript = hit.gameObject.GetComponent<PlayerController>();
-        if (hit.gameObject.CompareTag("Player") && !hitScript.isShielded())
-        {
-            // note that the 50 is a placeholder for real damage values later
-            // and that the player's health is base 100 for future reference
-            hitScript.takeDamage();
-        }
+	void OnCollisionEnter (Collision hit) {
+		PlayerController hitScript = hit.gameObject.GetComponent<PlayerController>();
+		if (hit.gameObject.CompareTag("Player") && !hitScript.isShielded()) {
+			hitScript.takeDamage();
+		}
+		//Destroy (gameObject);
+		Destroy();
+		//gameObject.SetActive(false);
+	}
 
-        // go through all cached triggers and remove the bullet from the count before destruction
-        for (int i = 0; i < cachedTrigger.Length; ++i)
-        {
-            if (cachedTrigger[i] != null && cachedTrigger[i].getNumBullets() > 0)
-            {
-                //cachedTrigger[i].decrementBulletCount();
-            }
+	void OnTriggerEnter(Collider volume)
+	{
+		if (volume.gameObject.CompareTag("Warning Radius"))
+		{
+			brackets.enabled = true;
+		}
 
-        }
+	}
 
-        //Destroy (gameObject);
-        //BulletDestroy.Destroy();
-        gameObject.SetActive(false);
-    }
+	void OnTriggerExit(Collider volume)
+	{
+		if (volume.gameObject.CompareTag("Warning Radius"))
+		{
+			brackets.enabled = false;
+		}
+	}
 
-    void OnTriggerEnter(Collider volume)
-    {
-        if (volume.gameObject.CompareTag("Warning Radius"))
-        {
-            brackets.enabled = true;
-        }
+	public int getAbsorbValue()
+	{
+		return absorbValue;
+	}
 
-        if (volume.gameObject.CompareTag("Threat Quadrant"))
-        {
-            ThreatTriggerController volumeScript = volume.gameObject.GetComponent<ThreatTriggerController>();
-            // check to see if a quadrant has already been cached
-            // if not add it
-            // increment the quadrant's count
-            for (int i = 0; i < cachedTrigger.Length; ++i)
-            {
-                if (cachedTrigger[i] == volumeScript)
-                {
-                    //cachedTrigger[i].incrementBulletCount();
-                    break;
-                }
-                if (cachedTrigger[i] == null)
-                {
-                    cachedTrigger[i] = volumeScript;
-                    //cachedTrigger[i].incrementBulletCount();
-                    break;
-                }
-            }
-        }
+	void OnEnable() {
+		Invoke ("Destroy", 20f);
+	}
 
-    }
+	public void Destroy() {
+		brackets.enabled = false;
+		GameObject radar = GameObject.FindGameObjectWithTag ("Radar3D");
+		if (radar) {
+			radar.GetComponent<Radar3D> ().RemoveBlip (gameObject);
+		}
+		GameObject[] threatQuadrants = GameObject.FindGameObjectsWithTag("Threat Quadrant");
+		for(int i = 0; i < threatQuadrants.Length; ++i)
+		{
+			threatQuadrants[i].GetComponent<ThreatTriggerController>().removeListElement(gameObject);
+		}
+		gameObject.SetActive (false);
+	}
 
-    void OnTriggerExit(Collider volume)
-    {
-        if (volume.gameObject.CompareTag("Warning Radius"))
-        {
-            brackets.enabled = false;
-        }
-
-        if (volume.gameObject.CompareTag("Threat Quadrant"))
-        {
-            ThreatTriggerController volumeScript = volume.gameObject.GetComponent<ThreatTriggerController>();
-            for (int i = 0; i < cachedTrigger.Length; ++i)
-            {
-                if (cachedTrigger[i] == volumeScript)
-                {
-                    cachedTrigger[i] = null;
-                    break;
-                }
-            }
-            //volumeScript.decrementBulletCount();
-        }
-    }
-
-    public int getAbsorbValue()
-    {
-        return absorbValue;
-    }
+	void OnDisable() {
+		CancelInvoke ();
+	}
 }

--- a/Assets/Scripts/Turrets/PointTurret.cs
+++ b/Assets/Scripts/Turrets/PointTurret.cs
@@ -16,13 +16,14 @@ public class PointTurret : SimpleTurret {
 
 	// Use this for initialization
 	void Start () {
-		//bulletVel = Velocity.Extreme;
+		bulletVel = Velocity.Extreme;
 		bulletColor = Color.blue;
+		fireRate = RateOfFire.High;
 		barrelList = new TurretBarrel[1];
 		barrelList [0] = new TurretBarrel ((float)bulletPrefab.GetComponent<Renderer>().bounds.size.x, 
-											(int)bulletVel);
+			(int)bulletVel);
 	}
-	
+
 	// Update is called once per frame
 	void Update () {
 		var distance = Vector3.Distance (gameObject.transform.position, target.transform.position);

--- a/Assets/Scripts/Turrets/PointTurret.cs
+++ b/Assets/Scripts/Turrets/PointTurret.cs
@@ -16,8 +16,9 @@ public class PointTurret : SimpleTurret {
 
 	// Use this for initialization
 	void Start () {
-		//bulletVel = Velocity.Extreme;
+		bulletVel = Velocity.Extreme;
 		bulletColor = Color.blue;
+		fireRate = RateOfFire.High;
 		barrelList = new TurretBarrel[1];
 		barrelList [0] = new TurretBarrel ((float)bulletPrefab.GetComponent<Renderer>().bounds.size.x, 
 											(int)bulletVel);

--- a/Assets/Scripts/Turrets/PointTurretLight.cs
+++ b/Assets/Scripts/Turrets/PointTurretLight.cs
@@ -1,15 +1,59 @@
-﻿using UnityEngine;
+﻿/*
+ * PointTurret.cs
+ * 
+ * Defines members specific to PointTurret child of SimpleTurret:
+ * - Fires single bullet toward player
+ * - Highest velocity bullets
+ * - Medium rate of fire
+ * - No acceleration
+ * - Blue bullets
+ */
+
+using UnityEngine;
 using System.Collections;
 
-public class PointTurretLight : MonoBehaviour {
+public class PointTurretLight : SimpleTurret {
 
 	// Use this for initialization
 	void Start () {
-	
+		bulletVel = Velocity.Extreme;
+		bulletColor = Color.blue;
+		fireRate = RateOfFire.High;
+		barrelList = new TurretBarrel[1];
+		barrelList [0] = new TurretBarrel ((float)bulletPrefab.GetComponent<Light>().range, 
+			(int)bulletVel);
 	}
-	
+
 	// Update is called once per frame
 	void Update () {
-	
+		var distance = Vector3.Distance (gameObject.transform.position, target.transform.position);
+		//if the player is within the turret's range of sight, target the player and fire
+		if (distance < sensorRange) {
+			gameObject.transform.LookAt (target.transform);
+			//find new point at end of turret once required to target player
+			Vector3 forwardNorm = gameObject.transform.forward;
+			forwardNorm.Normalize ();
+			endOfTurret = gameObject.GetComponent<Renderer> ().bounds.center + (forwardNorm * gameObject.GetComponent<Renderer> ().bounds.extents.z);
+			//if not firing, start firing
+			if (!isFiring) {
+				isFiring = true;
+				InvokeRepeating ("fire", (float)fireDelay, (float)fireRate * fireRateMultiplier);
+			}
+		}
+		//if the player is not within range, but the turret is firing, stop firing
+		else if (isFiring) {
+			isFiring = false;
+			CancelInvoke ("fire");
+		}
+	}
+
+	/*
+	 * Description: Creates new bullet with specifics
+	 * Post: new bullet is created with defined color and velocity
+	 */
+	protected void fire () {
+		Vector3 aimDirNorm = gameObject.transform.forward;
+		aimDirNorm.Normalize ();
+		CreateBullet (endOfTurret + (aimDirNorm * (barrelList [0].relativeSpawnPoint)), aimDirNorm);
 	}
 }

--- a/Assets/Scripts/Turrets/RakingTurret.cs
+++ b/Assets/Scripts/Turrets/RakingTurret.cs
@@ -21,7 +21,7 @@ public class RakingTurret : AlgorithmicTurret {
 	public float BULLET_SEPARATION = 0;
 	private float BULLET_WIDTH;
 	// Z-component must be a factor of 360
-	private Vector3 ROTATION_ANGLE = new Vector3 (0f, 0f, 15f);
+	public Vector3 ROTATION_ANGLE = new Vector3 (0f, 0f, 15f);
 
 	private int numFire = 0;
 	private bool rotatingLeft = true;
@@ -46,14 +46,20 @@ public class RakingTurret : AlgorithmicTurret {
 	
 	// Update is called once per frame
 	void Update () {
-		Vector3 forwardNorm = transform.forward;
-		forwardNorm.Normalize ();
-		endOfTurret = gameObject.GetComponent<Renderer> ().bounds.center + (forwardNorm * gameObject.GetComponent<Renderer> ().bounds.extents.z);
+		var distance = Vector3.Distance (gameObject.transform.position, target.transform.position);
+		if (distance < sensorRange || !fireOnlyWhenPlayerNear) {
+			Vector3 forwardNorm = transform.forward;
+			forwardNorm.Normalize ();
+			endOfTurret = gameObject.GetComponent<Renderer> ().bounds.center + (forwardNorm * gameObject.GetComponent<Renderer> ().bounds.extents.z);
 
-		//if not firing, start firing
-		if (!isFiring) {
-			isFiring = true;
-			InvokeRepeating ("fire", (float)fireDelay, (float)fireRate * fireRateMultiplier);
+			//if not firing, start firing
+			if (!isFiring) {
+				isFiring = true;
+				InvokeRepeating ("fire", (float)fireDelay, (float)fireRate * fireRateMultiplier);
+			}
+		} else if (fireOnlyWhenPlayerNear && isFiring) {
+			CancelInvoke ("fire");
+			isFiring = false;
 		}
 	}
 

--- a/Assets/Scripts/Turrets/RakingTurret.cs
+++ b/Assets/Scripts/Turrets/RakingTurret.cs
@@ -21,7 +21,7 @@ public class RakingTurret : AlgorithmicTurret {
 	public float BULLET_SEPARATION = 0;
 	private float BULLET_WIDTH;
 	// Z-component must be a factor of 360
-	private Vector3 ROTATION_ANGLE = new Vector3 (0f, 0f, 15f);
+	public Vector3 ROTATION_ANGLE = new Vector3 (0f, 0f, 15f);
 
 	private int numFire = 0;
 	private bool rotatingLeft = true;
@@ -43,17 +43,23 @@ public class RakingTurret : AlgorithmicTurret {
 				(int)bulletVel);
 		}
 	}
-	
+
 	// Update is called once per frame
 	void Update () {
-		Vector3 forwardNorm = transform.forward;
-		forwardNorm.Normalize ();
-		endOfTurret = gameObject.GetComponent<Renderer> ().bounds.center + (forwardNorm * gameObject.GetComponent<Renderer> ().bounds.extents.z);
+		var distance = Vector3.Distance (gameObject.transform.position, target.transform.position);
+		if (distance < sensorRange || !fireOnlyWhenPlayerNear) {
+			Vector3 forwardNorm = transform.forward;
+			forwardNorm.Normalize ();
+			endOfTurret = gameObject.GetComponent<Renderer> ().bounds.center + (forwardNorm * gameObject.GetComponent<Renderer> ().bounds.extents.z);
 
-		//if not firing, start firing
-		if (!isFiring) {
-			isFiring = true;
-			InvokeRepeating ("fire", (float)fireDelay, (float)fireRate * fireRateMultiplier);
+			//if not firing, start firing
+			if (!isFiring) {
+				isFiring = true;
+				InvokeRepeating ("fire", (float)fireDelay, (float)fireRate * fireRateMultiplier);
+			}
+		} else if (fireOnlyWhenPlayerNear && isFiring) {
+			CancelInvoke ("fire");
+			isFiring = false;
 		}
 	}
 

--- a/Assets/Scripts/Turrets/RakingTurretLight.cs
+++ b/Assets/Scripts/Turrets/RakingTurretLight.cs
@@ -1,15 +1,97 @@
-﻿using UnityEngine;
+﻿/*
+ * RakingTurret.cs
+ * 
+ * Defines members specific to RakingTurret child of AlgorithmicTurret:
+ * - Fires a variable number of bullets from opposite ends of one diameter
+ * - TurretBarrels swivel left and right as the turret rotates
+ * - Medium velocity bullets
+ * - High rate of fire
+ * - No acceleration
+ * - Yellow bullets
+ */
+
+using UnityEngine;
 using System.Collections;
 
-public class RakingTurretLight : MonoBehaviour {
+public class RakingTurretLight : AlgorithmicTurret {
+	public int NUM_BARRELS = 4;
+	public float TURRET_RADIUS = 4;
+	public float MAX_SWIVEL = Mathf.PI/3;
+	public float SWIVEL_PERCENTAGE = 0.1f;
+	public float BULLET_SEPARATION = 0;
+	private float BULLET_WIDTH;
+	// Z-component must be a factor of 360
+	private Vector3 ROTATION_ANGLE = new Vector3 (0f, 0f, 15f);
+
+	private int numFire = 0;
+	private bool rotatingLeft = true;
 
 	// Use this for initialization
 	void Start () {
-	
+		bulletVel = Velocity.Medium;
+		//orange
+		bulletColor = Color.yellow;
+		fireRate = RateOfFire.Extreme;
+		barrelList = new TurretBarrel[NUM_BARRELS];
+		Vector3 forwardNorm = transform.forward;
+		forwardNorm.Normalize ();
+		endOfTurret = gameObject.GetComponent<Renderer> ().bounds.center + (forwardNorm * gameObject.GetComponent<Renderer> ().bounds.extents.z);
+		BULLET_WIDTH = (float)bulletPrefab.GetComponent<Light> ().range;
+
+		for (int numBarrel = 0; numBarrel < NUM_BARRELS; ++numBarrel) {
+			barrelList[numBarrel] = new TurretBarrel (BULLET_WIDTH, 
+				(int)bulletVel);
+		}
 	}
-	
+
 	// Update is called once per frame
 	void Update () {
-	
+		Vector3 forwardNorm = transform.forward;
+		forwardNorm.Normalize ();
+		endOfTurret = gameObject.GetComponent<Renderer> ().bounds.center + (forwardNorm * gameObject.GetComponent<Renderer> ().bounds.extents.z);
+
+		//if not firing, start firing
+		if (!isFiring) {
+			isFiring = true;
+			InvokeRepeating ("fire", (float)fireDelay, (float)fireRate * fireRateMultiplier);
+		}
+	}
+
+	/*
+	 * Description: Shoots NUM_BARRELS bullets, half from one side of the turret and half from the other, as the TurretBarrels swivel left and right
+	 * Post: A bullet has been fired from all TurretBarrels
+	 */
+	protected void fire() {
+		Vector3 aimDirNorm = transform.forward;
+		aimDirNorm.Normalize ();
+		Vector3 rightNorm = transform.right;
+		rightNorm.Normalize ();
+		Vector3 upNorm = transform.up;
+		upNorm.Normalize ();
+
+		GameObject bulletObj;
+		Bullet newBullet;
+
+		//create each bullet
+		for (int numBarrel = 0; numBarrel < NUM_BARRELS; ++numBarrel) {
+			Vector3 rotVector = Vector3.RotateTowards (aimDirNorm, rightNorm, numFire * MAX_SWIVEL * SWIVEL_PERCENTAGE, 0f);
+			if (numBarrel % 2 == 0) {
+				CreateBullet (endOfTurret - (rightNorm * TURRET_RADIUS) - (Mathf.Floor (numBarrel / 2) * (BULLET_WIDTH + BULLET_SEPARATION) * rightNorm), rotVector);
+			} else {
+				CreateBullet (endOfTurret + (rightNorm * TURRET_RADIUS) + (Mathf.Floor (numBarrel / 2) * (BULLET_WIDTH + BULLET_SEPARATION) * rightNorm), rotVector);
+			}
+		}
+
+		if (Mathf.Abs (numFire) + 1 > 1 / SWIVEL_PERCENTAGE) {
+			rotatingLeft = !rotatingLeft;
+		}
+
+		if (rotatingLeft)
+			--numFire;
+		else
+			++numFire;
+
+		//rotate the turret by the given angle
+		transform.Rotate (ROTATION_ANGLE);
 	}
 }

--- a/Assets/Scripts/Turrets/SimpleTurret.cs
+++ b/Assets/Scripts/Turrets/SimpleTurret.cs
@@ -16,7 +16,7 @@ using System.Collections;
 public class SimpleTurret : Turret {
 
 	public GameObject target;
-	public float sensorRange = 50;
+	protected float sensorRange = 50;
 
 	// Use this for initialization
 	void Start () {

--- a/Assets/Scripts/Turrets/SimpleTurret.cs
+++ b/Assets/Scripts/Turrets/SimpleTurret.cs
@@ -16,7 +16,7 @@ using System.Collections;
 public class SimpleTurret : Turret {
 
 	public GameObject target;
-	public float sensorRange = 50;
+	protected float sensorRange = 30;
 
 	// Use this for initialization
 	void Start () {

--- a/Assets/Scripts/Turrets/T_Turret.cs
+++ b/Assets/Scripts/Turrets/T_Turret.cs
@@ -16,15 +16,15 @@ public class T_Turret : SimpleTurret {
 
 	private int numShots = 0;
 	private int numFire = 0;
-	private int BULLET_FREQUENCY = 200;
-	public int BARREL_SEPARATION = 1;
+	private int BULLET_FREQUENCY = 1;
+	private int BARREL_SEPARATION = 1;
 	private Vector3 ROTATION_ANGLE = new Vector3 (0f, 0f, 15f);
 
 	// Use this for initialization
 	void Start () {
-		//bulletVel = Velocity.Extreme;
+		bulletVel = Velocity.Extreme;
 		bulletColor = Color.cyan;
-		//fireRate = RateOfFire.High;
+		fireRate = RateOfFire.High;
 		barrelList = new TurretBarrel[3];
 
 		//left
@@ -72,7 +72,7 @@ public class T_Turret : SimpleTurret {
 	 *       Turret's angle of rotation is increased or reset
 	 */
 	protected void fire () {
-		InvokeRepeating ("singleBurst", (float)fireDelay, (float)fireRate / BULLET_FREQUENCY);
+		InvokeRepeating ("singleBurst", (float)fireDelay, (float)fireRate * fireRateMultiplier / BULLET_FREQUENCY);
 
 		//if the turret has made a complete rotation, reset the number of times it has been fired
 		if (numFire == 360 / ROTATION_ANGLE.z)

--- a/Assets/Scripts/Turrets/T_Turret.cs
+++ b/Assets/Scripts/Turrets/T_Turret.cs
@@ -16,15 +16,15 @@ public class T_Turret : SimpleTurret {
 
 	private int numShots = 0;
 	private int numFire = 0;
-	private int BULLET_FREQUENCY = 200;
+	public int BULLET_FREQUENCY = 10;
 	public int BARREL_SEPARATION = 1;
-	private Vector3 ROTATION_ANGLE = new Vector3 (0f, 0f, 15f);
+	public Vector3 ROTATION_ANGLE = new Vector3 (0f, 0f, 15f);
 
 	// Use this for initialization
 	void Start () {
-		//bulletVel = Velocity.Extreme;
+		bulletVel = Velocity.Extreme;
 		bulletColor = Color.cyan;
-		//fireRate = RateOfFire.High;
+		fireRate = RateOfFire.High;
 		barrelList = new TurretBarrel[3];
 
 		//left
@@ -37,7 +37,7 @@ public class T_Turret : SimpleTurret {
 		barrelList [2] = new TurretBarrel ((float)bulletPrefab.GetComponent<Renderer>().bounds.size.x, 
 			(int)bulletVel);
 	}
-	
+
 	// Update is called once per frame
 	void Update () {
 		var distance = Vector3.Distance (gameObject.transform.position, target.transform.position);
@@ -72,7 +72,7 @@ public class T_Turret : SimpleTurret {
 	 *       Turret's angle of rotation is increased or reset
 	 */
 	protected void fire () {
-		InvokeRepeating ("singleBurst", (float)fireDelay, (float)fireRate / BULLET_FREQUENCY);
+		InvokeRepeating ("singleBurst", (float)fireDelay, (float)fireRate * fireRateMultiplier / BULLET_FREQUENCY);
 
 		//if the turret has made a complete rotation, reset the number of times it has been fired
 		if (numFire == 360 / ROTATION_ANGLE.z)

--- a/Assets/Scripts/Turrets/T_TurretLight.cs
+++ b/Assets/Scripts/Turrets/T_TurretLight.cs
@@ -1,15 +1,112 @@
-﻿using UnityEngine;
+﻿/*
+ * T_Turret.cs
+ * 
+ * Defines members specific to T-Turret child of SimpleTurret:
+ * - Fires seven bullets in 'T' shape toward player
+ * - Highest velocity bullets
+ * - High rate of fire
+ * - No acceleration
+ * - Cyan bullets
+ */
+
+using UnityEngine;
 using System.Collections;
 
-public class T_TurretLight : MonoBehaviour {
+public class T_TurretLight : SimpleTurret {
+
+	private int numShots = 0;
+	private int numFire = 0;
+	private int BULLET_FREQUENCY = 200;
+	private int BARREL_SEPARATION = 1;
+	private Vector3 ROTATION_ANGLE = new Vector3 (0f, 0f, 15f);
 
 	// Use this for initialization
 	void Start () {
-	
+		bulletVel = Velocity.Extreme;
+		bulletColor = Color.cyan;
+		fireRate = RateOfFire.High;
+		barrelList = new TurretBarrel[3];
+
+		//left
+		barrelList [0] = new TurretBarrel ((float)bulletPrefab.GetComponent<Light>().range, 
+			(int)bulletVel);
+		//center
+		barrelList [1] = new TurretBarrel ((float)bulletPrefab.GetComponent<Light>().range, 
+			(int)bulletVel);
+		//right
+		barrelList [2] = new TurretBarrel ((float)bulletPrefab.GetComponent<Light>().range, 
+			(int)bulletVel);
 	}
-	
+
 	// Update is called once per frame
 	void Update () {
-	
+		var distance = Vector3.Distance (gameObject.transform.position, target.transform.position);
+		//if the player is within the turret's range of sight, target the player and fire
+		if (distance < sensorRange) {
+			if (numShots == 0) {
+				gameObject.transform.LookAt (target.transform);
+				//give appropriate rotation for the number of times the turret has fired
+				transform.Rotate (ROTATION_ANGLE * numFire);
+
+				//find new point at end of turret once required to target player
+				Vector3 forwardNorm = gameObject.transform.forward;
+				forwardNorm.Normalize ();
+				endOfTurret = gameObject.GetComponent<Renderer> ().bounds.center + (forwardNorm * gameObject.GetComponent<Renderer> ().bounds.extents.z);
+			}
+			//if not firing, start firing
+			if (!isFiring) {
+				isFiring = true;
+				InvokeRepeating ("fire", (float)fireDelay, (float)fireRate * fireRateMultiplier);
+			}
+		}
+		//if the player is not within range, but the turret is firing, stop firing
+		else if (isFiring) {
+			isFiring = false;
+			CancelInvoke ("fire");
+		}
+	}
+
+	/*
+	 * Description: Calls for a burst of bullets
+	 * Post: singleBurst() is set to be called repeatedly
+	 *       Turret's angle of rotation is increased or reset
+	 */
+	protected void fire () {
+		InvokeRepeating ("singleBurst", (float)fireDelay, (float)fireRate / BULLET_FREQUENCY);
+
+		//if the turret has made a complete rotation, reset the number of times it has been fired
+		if (numFire == 360 / ROTATION_ANGLE.z)
+			numFire = 1;
+		//else increase the number of times the turret has been fired
+		else
+			++numFire;
+	}
+
+	/*
+	 * Description: Creates a certain number of bullets depending on which part of the 'T' is to be fired
+	 * Pre: numShots is within the set {0, ..., 4}
+	 * Post: If numShots is less than 4, one bullet is fired from the central barrel
+	 *       If numShots is equal to 4, one bullet is fired from each barrel, and numshots is reset
+	 */
+	protected void singleBurst() {
+		if (numShots == 4) {
+			Vector3 rightNorm = transform.right;
+			rightNorm.Normalize ();
+
+			Vector3 aimDirNorm = gameObject.transform.forward;
+			aimDirNorm.Normalize ();
+			CreateBullet (endOfTurret + (rightNorm * BARREL_SEPARATION) + (aimDirNorm * (barrelList [0].relativeSpawnPoint)), aimDirNorm);
+			CreateBullet (endOfTurret + (aimDirNorm * (barrelList [1].relativeSpawnPoint)), aimDirNorm);
+			CreateBullet (endOfTurret + (-1 * rightNorm * BARREL_SEPARATION) + (aimDirNorm * (barrelList [0].relativeSpawnPoint)), aimDirNorm);
+
+			CancelInvoke ("singleBurst");
+			numShots = 0;
+		}
+		else {
+			Vector3 aimDirNorm = gameObject.transform.forward;
+			aimDirNorm.Normalize ();
+			CreateBullet (endOfTurret + (aimDirNorm * (barrelList [1].relativeSpawnPoint)), aimDirNorm);
+			++numShots;
+		}
 	}
 }

--- a/Assets/Scripts/Turrets/TriangleFlatLight.cs
+++ b/Assets/Scripts/Turrets/TriangleFlatLight.cs
@@ -1,130 +1,131 @@
-﻿using UnityEngine;
+﻿/*
+ * TriangleTurret_Flat.cs
+ * 
+ * Defines members specific to ArcTurret child of SimpleTurret:
+ * - Fires six bullets in flat (horizontal) triangle shape toward player
+ * - Low velocity bullets
+ * - Medium rate of fire
+ * - No acceleration
+ * - Magenta bullets
+ */
+
+using UnityEngine;
 using System.Collections;
 
 public class TriangleFlatLight : SimpleTurret {
 
-    private int numShots = 0;
-    private int numFire = 0;
-    private int BULLET_FREQUENCY = 150;
-    //multiplied by normalized vector on the local 
-    private float BARREL_SEPARATION = 0.25f;
-    private Vector3 ROTATION_ANGLE = new Vector3(0f, 0f, 15f);
+	private int numShots = 0;
+	private int numFire = 0;
+	private int BULLET_FREQUENCY = 75;
+	//multiplied by normalized vector on the local 
+	private float BARREL_SEPARATION = 0.25f;
+	private Vector3 ROTATION_ANGLE = new Vector3 (0f, 0f, 15f);
 
-    // Use this for initialization
-    void Start()
-    {
-        bulletVel = Velocity.Low;
-        bulletColor = Color.magenta;
-        fireRate = RateOfFire.Medium;
-        barrelList = new TurretBarrel[5];
+	// Use this for initialization
+	void Start () {
+		bulletVel = Velocity.Medium;
+		bulletColor = Color.magenta;
+		fireRate = RateOfFire.Medium;
+		barrelList = new TurretBarrel[5];
 
-        //leftmost
-        barrelList[0] = new TurretBarrel((float)bulletPrefab.GetComponent<Renderer>().bounds.size.x,
-            (int)bulletVel);
-        //center-left
-        barrelList[1] = new TurretBarrel((float)bulletPrefab.GetComponent<Renderer>().bounds.size.x,
-            (int)bulletVel);
-        //center
-        barrelList[2] = new TurretBarrel((float)bulletPrefab.GetComponent<Renderer>().bounds.size.x,
-            (int)bulletVel);
-        //center-right
-        barrelList[3] = new TurretBarrel((float)bulletPrefab.GetComponent<Renderer>().bounds.size.x,
-            (int)bulletVel);
-        //rightmost
-        barrelList[4] = new TurretBarrel((float)bulletPrefab.GetComponent<Renderer>().bounds.size.x,
-            (int)bulletVel);
-    }
+		//leftmost
+		barrelList [0] = new TurretBarrel ((float)bulletPrefab.GetComponent<Light>().range, 
+			(int)bulletVel);
+		//center-left
+		barrelList [1] = new TurretBarrel ((float)bulletPrefab.GetComponent<Light>().range, 
+			(int)bulletVel);
+		//center
+		barrelList [2] = new TurretBarrel ((float)bulletPrefab.GetComponent<Light>().range, 
+			(int)bulletVel);
+		//center-right
+		barrelList [3] = new TurretBarrel ((float)bulletPrefab.GetComponent<Light>().range, 
+			(int)bulletVel);
+		//rightmost
+		barrelList [4] = new TurretBarrel ((float)bulletPrefab.GetComponent<Light>().range, 
+			(int)bulletVel);
+	}
 
-    // Update is called once per frame
-    void Update()
-    {
-        var distance = Vector3.Distance(gameObject.transform.position, target.transform.position);
-        //if the player is within the turret's range of sight, target the player and fire
-        if (distance < sensorRange)
-        {
-            if (numShots == 0)
-            {
-                gameObject.transform.LookAt(target.transform);
-                //give appropriate rotation for the number of times the turret has fired
-                transform.Rotate(ROTATION_ANGLE * numFire);
+	// Update is called once per frame
+	void Update () {
+		var distance = Vector3.Distance (gameObject.transform.position, target.transform.position);
+		//if the player is within the turret's range of sight, target the player and fire
+		if (distance < sensorRange) {
+			if (numShots == 0) {
+				gameObject.transform.LookAt (target.transform);
+				//give appropriate rotation for the number of times the turret has fired
+				transform.Rotate (ROTATION_ANGLE * numFire);
 
-                //find new point at end of turret once required to target player
-                Vector3 forwardNorm = gameObject.transform.forward;
-                forwardNorm.Normalize();
-                endOfTurret = gameObject.GetComponent<Renderer>().bounds.center + (forwardNorm * gameObject.GetComponent<Renderer>().bounds.extents.z);
-            }
-            //if not firing, start firing
-            if (!isFiring)
-            {
-                isFiring = true;
-                InvokeRepeating("fire", (float)fireDelay, (float)fireRate * fireRateMultiplier);
-            }
-        }
-        //if the player is not within range, but the turret is firing, stop firing
-        else if (isFiring)
-        {
-            isFiring = false;
-            CancelInvoke("fire");
-        }
-    }
+				//find new point at end of turret once required to target player
+				Vector3 forwardNorm = gameObject.transform.forward;
+				forwardNorm.Normalize ();
+				endOfTurret = gameObject.GetComponent<Renderer> ().bounds.center + (forwardNorm * gameObject.GetComponent<Renderer> ().bounds.extents.z);
+			}
+			//if not firing, start firing
+			if (!isFiring) {
+				isFiring = true;
+				InvokeRepeating ("fire", (float)fireDelay, (float)fireRate * fireRateMultiplier);
+			}
+		}
+		//if the player is not within range, but the turret is firing, stop firing
+		else if (isFiring) {
+			isFiring = false;
+			CancelInvoke ("fire");
+		}
+	}
 
-    /*
+	/*
 	 * Description: Calls for a burst of bullets
 	 * Post: singleBurst() is set to be called repeatedly
 	 *       Turret's angle of rotation is increased or reset
 	 */
-    protected void fire()
-    {
-        InvokeRepeating("singleBurst", (float)fireDelay, (float)fireRate / BULLET_FREQUENCY);
+	protected void fire () {
+		InvokeRepeating ("singleBurst", (float)fireDelay, (float)fireRate / BULLET_FREQUENCY);
 
-        //if the turret has made a complete rotation, reset the number of times it has been fired
-        if (numFire == 360 / ROTATION_ANGLE.z)
-            numFire = 1;
-        //else increase the number of times the turret has been fired
-        else
-            ++numFire;
-    }
+		//if the turret has made a complete rotation, reset the number of times it has been fired
+		if (numFire == 360 / ROTATION_ANGLE.z)
+			numFire = 1;
+		//else increase the number of times the turret has been fired
+		else
+			++numFire;
+	}
 
-    /*
+	/*
 	 * Description: Creates a certain number of bullets depending on which part of the triangle is to be fired
 	 * Pre: numShots is within the set {0, 1, 2}
 	 * Post: If numShots is equal to 0, one bullet is fired from the central barrel
 	 *       If numShots is equal to 1, one bullet is fired from each barrel directly beside the central barrel
 	 *       If numShots is equal to 2, one bullet is fired from each of the end barrels, and numShots is reset
 	 */
-    protected void singleBurst()
-    {
-        Vector3 aimDirNorm = gameObject.transform.forward;
-        aimDirNorm.Normalize();
-        Vector3 rightNorm = transform.right;
-        rightNorm.Normalize();
-        GameObject bulletObj;
-        Bullet newBullet;
+	protected void singleBurst() {
+		Vector3 aimDirNorm = gameObject.transform.forward;
+		aimDirNorm.Normalize ();
+		Vector3 rightNorm = transform.right;
+		rightNorm.Normalize ();
+		GameObject bulletObj;
+		Bullet newBullet;
 
-        switch (numShots)
-        {
-            case 0:
-                CreateBullet(endOfTurret + (aimDirNorm * (barrelList[2].relativeSpawnPoint)), aimDirNorm);
-                ++numShots;
+		switch (numShots) {
+		case 0:
+			CreateBullet (endOfTurret + (aimDirNorm * (barrelList [2].relativeSpawnPoint)), aimDirNorm);
+			++numShots;
 
-                break;
-            case 1:
-                CreateBullet(endOfTurret + (rightNorm * BARREL_SEPARATION) + (aimDirNorm * (barrelList[1].relativeSpawnPoint)), aimDirNorm);
-                CreateBullet(endOfTurret + (-1 * rightNorm * BARREL_SEPARATION) + (aimDirNorm * (barrelList[3].relativeSpawnPoint)), aimDirNorm);
-                ++numShots;
+			break;
+		case 1:
+			CreateBullet (endOfTurret + (rightNorm * BARREL_SEPARATION) + (aimDirNorm * (barrelList [1].relativeSpawnPoint)), aimDirNorm);
+			CreateBullet (endOfTurret + (-1 * rightNorm * BARREL_SEPARATION) + (aimDirNorm * (barrelList [3].relativeSpawnPoint)), aimDirNorm);
+			++numShots;
 
-                break;
-            case 2:
-                CreateBullet(endOfTurret + (2 * rightNorm * BARREL_SEPARATION) + (aimDirNorm * (barrelList[0].relativeSpawnPoint)), aimDirNorm);
-                CreateBullet(endOfTurret + (aimDirNorm * (barrelList[2].relativeSpawnPoint)), aimDirNorm);
-                CreateBullet(endOfTurret + (-2 * rightNorm * BARREL_SEPARATION) + (aimDirNorm * (barrelList[4].relativeSpawnPoint)), aimDirNorm);
-                CancelInvoke("singleBurst");
-                numShots = 0;
+			break;
+		case 2:
+			CreateBullet (endOfTurret + (2 * rightNorm * BARREL_SEPARATION) + (aimDirNorm * (barrelList [0].relativeSpawnPoint)), aimDirNorm);
+			CreateBullet (endOfTurret + (aimDirNorm * (barrelList [2].relativeSpawnPoint)), aimDirNorm);
+			CreateBullet (endOfTurret + (-2 * rightNorm * BARREL_SEPARATION) + (aimDirNorm * (barrelList [4].relativeSpawnPoint)), aimDirNorm);
+			CancelInvoke ("singleBurst");
+			numShots = 0;
 
-                break;
-            default:
-                break;
-        }
-    }
+			break;
+		default:
+			break;
+		}
+	}
 }
-

--- a/Assets/Scripts/Turrets/TriangleTurret_Flat.cs
+++ b/Assets/Scripts/Turrets/TriangleTurret_Flat.cs
@@ -16,16 +16,16 @@ public class TriangleTurret_Flat : SimpleTurret {
 
 	private int numShots = 0;
 	private int numFire = 0;
-	private int BULLET_FREQUENCY = 150;
+	public float BULLET_FREQUENCY = 7f;
 	//multiplied by normalized vector on the local 
-	private float BARREL_SEPARATION = 0.25f;
-	private Vector3 ROTATION_ANGLE = new Vector3 (0f, 0f, 15f);
+	public float BARREL_SEPARATION = 0.25f;
+	public Vector3 ROTATION_ANGLE = new Vector3 (0f, 0f, 15f);
 
 	// Use this for initialization
 	void Start () {
-		bulletVel = Velocity.Low;
+		bulletVel = Velocity.Medium;
 		bulletColor = Color.magenta;
-		fireRate = RateOfFire.Medium;
+		fireRate = RateOfFire.Low;
 		barrelList = new TurretBarrel[5];
 
 		//leftmost
@@ -44,7 +44,7 @@ public class TriangleTurret_Flat : SimpleTurret {
 		barrelList [4] = new TurretBarrel ((float)bulletPrefab.GetComponent<Renderer>().bounds.size.x, 
 			(int)bulletVel);
 	}
-	
+
 	// Update is called once per frame
 	void Update () {
 		var distance = Vector3.Distance (gameObject.transform.position, target.transform.position);
@@ -79,7 +79,7 @@ public class TriangleTurret_Flat : SimpleTurret {
 	 *       Turret's angle of rotation is increased or reset
 	 */
 	protected void fire () {
-		InvokeRepeating ("singleBurst", (float)fireDelay, (float)fireRate / BULLET_FREQUENCY);
+		InvokeRepeating ("singleBurst", (float)fireDelay, (float)fireRate * fireRateMultiplier / BULLET_FREQUENCY);
 
 		//if the turret has made a complete rotation, reset the number of times it has been fired
 		if (numFire == 360 / ROTATION_ANGLE.z)

--- a/Assets/Scripts/Turrets/TriangleTurret_Flat.cs
+++ b/Assets/Scripts/Turrets/TriangleTurret_Flat.cs
@@ -16,16 +16,16 @@ public class TriangleTurret_Flat : SimpleTurret {
 
 	private int numShots = 0;
 	private int numFire = 0;
-	private int BULLET_FREQUENCY = 150;
+	private float BULLET_FREQUENCY = 7f;
 	//multiplied by normalized vector on the local 
 	private float BARREL_SEPARATION = 0.25f;
 	private Vector3 ROTATION_ANGLE = new Vector3 (0f, 0f, 15f);
 
 	// Use this for initialization
 	void Start () {
-		bulletVel = Velocity.Low;
+		bulletVel = Velocity.Medium;
 		bulletColor = Color.magenta;
-		fireRate = RateOfFire.Medium;
+		fireRate = RateOfFire.Low;
 		barrelList = new TurretBarrel[5];
 
 		//leftmost
@@ -79,7 +79,7 @@ public class TriangleTurret_Flat : SimpleTurret {
 	 *       Turret's angle of rotation is increased or reset
 	 */
 	protected void fire () {
-		InvokeRepeating ("singleBurst", (float)fireDelay, (float)fireRate / BULLET_FREQUENCY);
+		InvokeRepeating ("singleBurst", (float)fireDelay, (float)fireRate * fireRateMultiplier / BULLET_FREQUENCY);
 
 		//if the turret has made a complete rotation, reset the number of times it has been fired
 		if (numFire == 360 / ROTATION_ANGLE.z)

--- a/Assets/Scripts/Turrets/TriangleTurret_Wall.cs
+++ b/Assets/Scripts/Turrets/TriangleTurret_Wall.cs
@@ -15,17 +15,17 @@ using System.Collections;
 public class TriangleTurret_Wall : SimpleTurret {
 
 	private int numFire = 0;
-	private Vector3 ROTATION_ANGLE = new Vector3 (0f, 0f, 15f);
+	public Vector3 ROTATION_ANGLE = new Vector3 (0f, 0f, 15f);
 
 	//angle between the rays from barrel 0 to barrel 3 and from barrel 0 to barrel 5
-	private const float TRIANGLE_ANGLE = Mathf.PI / 3f;
-	private float TRIANGLE_HEIGHT;
+	public const float TRIANGLE_ANGLE = Mathf.PI / 3f;
+	public float TRIANGLE_HEIGHT;
 
 	// Use this for initialization
 	void Start () {
-		//bulletVel = Velocity.Low;
+		bulletVel = Velocity.Medium;
 		bulletColor = Color.magenta;
-		//fireRate = RateOfFire.Medium;
+		fireRate = RateOfFire.Medium;
 		barrelList = new TurretBarrel[6];
 		TRIANGLE_HEIGHT = 3f * (float)bulletPrefab.GetComponent<Renderer> ().bounds.size.x;
 
@@ -48,7 +48,7 @@ public class TriangleTurret_Wall : SimpleTurret {
 		barrelList [5] = new TurretBarrel ((float)bulletPrefab.GetComponent<Renderer>().bounds.size.x, 
 			(int)bulletVel);
 	}
-	
+
 	// Update is called once per frame
 	void Update () {
 		var distance = Vector3.Distance (gameObject.transform.position, target.transform.position);

--- a/Assets/Scripts/Turrets/TriangleTurret_Wall.cs
+++ b/Assets/Scripts/Turrets/TriangleTurret_Wall.cs
@@ -15,17 +15,17 @@ using System.Collections;
 public class TriangleTurret_Wall : SimpleTurret {
 
 	private int numFire = 0;
-	private Vector3 ROTATION_ANGLE = new Vector3 (0f, 0f, 15f);
+	public Vector3 ROTATION_ANGLE = new Vector3 (0f, 0f, 15f);
 
 	//angle between the rays from barrel 0 to barrel 3 and from barrel 0 to barrel 5
-	private const float TRIANGLE_ANGLE = Mathf.PI / 3f;
-	private float TRIANGLE_HEIGHT;
+	public const float TRIANGLE_ANGLE = Mathf.PI / 3f;
+	public float TRIANGLE_HEIGHT;
 
 	// Use this for initialization
 	void Start () {
-		//bulletVel = Velocity.Low;
+		bulletVel = Velocity.Medium;
 		bulletColor = Color.magenta;
-		//fireRate = RateOfFire.Medium;
+		fireRate = RateOfFire.Medium;
 		barrelList = new TurretBarrel[6];
 		TRIANGLE_HEIGHT = 3f * (float)bulletPrefab.GetComponent<Renderer> ().bounds.size.x;
 

--- a/Assets/Scripts/Turrets/TriangleWallLight.cs
+++ b/Assets/Scripts/Turrets/TriangleWallLight.cs
@@ -1,15 +1,110 @@
-﻿using UnityEngine;
+﻿/*
+ * TriangleTurret_Wall.cs
+ * 
+ * Defines members specific to ArcTurret child of SimpleTurret:
+ * - Fires six bullets in wall-like (vertical) triangle shape toward player
+ * - Low velocity bullets
+ * - Medium rate of fire
+ * - No acceleration
+ * - Magenta bullets
+ */
+
+using UnityEngine;
 using System.Collections;
 
-public class TriangleWallLight : MonoBehaviour {
+public class TriangleWallLight : SimpleTurret {
+
+	private int numFire = 0;
+	public Vector3 ROTATION_ANGLE = new Vector3 (0f, 0f, 15f);
+
+	//angle between the rays from barrel 0 to barrel 3 and from barrel 0 to barrel 5
+	public const float TRIANGLE_ANGLE = Mathf.PI / 3f;
+	public float TRIANGLE_HEIGHT;
 
 	// Use this for initialization
 	void Start () {
-	
+		bulletVel = Velocity.Low;
+		bulletColor = Color.magenta;
+		fireRate = RateOfFire.Medium;
+		barrelList = new TurretBarrel[6];
+		TRIANGLE_HEIGHT = 3f * (float)bulletPrefab.GetComponent<Light>().range;
+
+		//top
+		barrelList [0] = new TurretBarrel ((float)bulletPrefab.GetComponent<Light>().range, 
+			(int)bulletVel);
+		//center-left
+		barrelList [1] = new TurretBarrel ((float)bulletPrefab.GetComponent<Light>().range, 
+			(int)bulletVel);
+		//center-right
+		barrelList [2] = new TurretBarrel ((float)bulletPrefab.GetComponent<Light>().range, 
+			(int)bulletVel);
+		//back-left
+		barrelList [3] = new TurretBarrel ((float)bulletPrefab.GetComponent<Light>().range, 
+			(int)bulletVel);
+		//bottom-center
+		barrelList [4] = new TurretBarrel ((float)bulletPrefab.GetComponent<Light>().range, 
+			(int)bulletVel);
+		//bottom-right
+		barrelList [5] = new TurretBarrel ((float)bulletPrefab.GetComponent<Light>().range, 
+			(int)bulletVel);
 	}
-	
+
 	// Update is called once per frame
 	void Update () {
-	
+		var distance = Vector3.Distance (gameObject.transform.position, target.transform.position);
+		//if the player is within the turret's range of sight, target the player and fire
+		if (distance < sensorRange) {
+			gameObject.transform.LookAt (target.transform);
+
+			//give appropriate rotation for the number of times the turret has fired
+			transform.Rotate (ROTATION_ANGLE * numFire);
+
+			//find new point at end of turret once required to target player
+			Vector3 forwardNorm = gameObject.transform.forward;
+			forwardNorm.Normalize ();
+			endOfTurret = gameObject.GetComponent<Renderer> ().bounds.center + (forwardNorm * gameObject.GetComponent<Renderer> ().bounds.extents.z);
+			//if not firing, start firing
+			if (!isFiring) {
+				isFiring = true;
+				InvokeRepeating ("fire", (float)fireDelay, (float)fireRate * fireRateMultiplier);
+			}
+		}
+		//if the player is not within range, but the turret is firing, stop firing
+		else if (isFiring) {
+			isFiring = false;
+			CancelInvoke ("fire");
+		}
 	}
+
+	/*
+	 * Description: Shoots six bullets in a triangle shape
+	 * Post: A bullet has been fired from all TurretBarrels
+	 */
+	protected void fire() {
+		Vector3 aimDirNorm = gameObject.transform.forward;
+		aimDirNorm.Normalize ();
+		Vector3 rightNorm = transform.right;
+		rightNorm.Normalize ();
+		Vector3 upNorm = transform.up;
+		upNorm.Normalize ();
+
+		//distance between barrels 1 and 2 (second row of barrels) - same as half width of base of triangle
+		float middleDist = Mathf.Tan(TRIANGLE_ANGLE / 2) * TRIANGLE_HEIGHT;
+
+		CreateBullet (endOfTurret + (TRIANGLE_HEIGHT / 2 * upNorm) + (aimDirNorm * (barrelList [0].relativeSpawnPoint)), aimDirNorm);
+		CreateBullet (endOfTurret + (-1 * middleDist / 2 * rightNorm) + (aimDirNorm * (barrelList [1].relativeSpawnPoint)), aimDirNorm);
+		CreateBullet (endOfTurret + (middleDist / 2 * rightNorm) + (aimDirNorm * (barrelList [2].relativeSpawnPoint)), aimDirNorm);
+		CreateBullet (endOfTurret + (-1 * middleDist * rightNorm) + (-1 * TRIANGLE_HEIGHT / 2 * upNorm) + (aimDirNorm * (barrelList [3].relativeSpawnPoint)), aimDirNorm);
+		CreateBullet (endOfTurret + (-1 * TRIANGLE_HEIGHT / 2 * upNorm) + (aimDirNorm * (barrelList [4].relativeSpawnPoint)), aimDirNorm);
+		CreateBullet (endOfTurret + (middleDist * rightNorm) + (-1 * TRIANGLE_HEIGHT / 2 * upNorm) + (aimDirNorm * (barrelList [5].relativeSpawnPoint)), aimDirNorm);
+
+		//if the turret has made a complete rotation, reset the number of times it has been fired
+		if (numFire == 360 / ROTATION_ANGLE.z)
+			numFire = 1;
+		//else increase the number of times the turret has been fired
+		else
+			++numFire;
+	}
+
+
 }

--- a/Assets/Scripts/Turrets/Turret.cs
+++ b/Assets/Scripts/Turrets/Turret.cs
@@ -14,17 +14,17 @@ using System.Collections;
 public class Turret : MonoBehaviour {
 
 	//higher number = higher velocity
-	public enum Velocity {Low = 1, Medium = 4, High = 7, Extreme = 10, EuropeanExtreme = 30};
+	protected enum Velocity {Low = 2, Medium = 4, High = 7, Extreme = 10};
 	//lower number = higher rate
-	public enum RateOfFire {Low = 20, Medium = 10, High = 5, Extreme = 2};
+	protected enum RateOfFire {Low = 20, Medium = 10, High = 5, Extreme = 2};
 	protected Quaternion zQuat = new Quaternion (0f, 0f, 0f, 0f);
 
 	protected Vector3 turretPos;
 	protected Quaternion turretRot = new Quaternion(0, 0, 0, 0);
-	public Velocity bulletVel;
+	protected Velocity bulletVel;
 	protected Vector4 bulletColor;
 	protected TurretBarrel[] barrelList;
-	public RateOfFire fireRate;
+	protected RateOfFire fireRate;
 	protected float fireRateMultiplier = 0.1f;
 	protected bool isFiring = false;
 	protected float fireDelay = 0;
@@ -51,6 +51,7 @@ public class Turret : MonoBehaviour {
 
 		obj.transform.position = position;
 		obj.transform.rotation = transform.rotation;
+		//LightBulletController bulletObj = (LightBulletController)obj.GetComponent (typeof(LightBulletController));
 		Bullet bulletObj = (Bullet)obj.GetComponent (typeof(Bullet));
 		bulletObj.setVars (bulletColor, aimDirectionNorm * (float)bulletVel);
 		obj.SetActive (true);

--- a/Assets/Scripts/Turrets/Turret.cs
+++ b/Assets/Scripts/Turrets/Turret.cs
@@ -14,17 +14,17 @@ using System.Collections;
 public class Turret : MonoBehaviour {
 
 	//higher number = higher velocity
-	public enum Velocity {Low = 1, Medium = 4, High = 7, Extreme = 10, EuropeanExtreme = 30};
+	protected enum Velocity {Low = 1, Medium = 4, High = 7, Extreme = 10, EuropeanExtreme = 30};
 	//lower number = higher rate
-	public enum RateOfFire {Low = 20, Medium = 10, High = 5, Extreme = 2};
+	protected enum RateOfFire {Low = 20, Medium = 10, High = 5, Extreme = 2};
 	protected Quaternion zQuat = new Quaternion (0f, 0f, 0f, 0f);
 
 	protected Vector3 turretPos;
 	protected Quaternion turretRot = new Quaternion(0, 0, 0, 0);
-	public Velocity bulletVel;
+	protected Velocity bulletVel;
 	protected Vector4 bulletColor;
 	protected TurretBarrel[] barrelList;
-	public RateOfFire fireRate;
+	protected RateOfFire fireRate;
 	protected float fireRateMultiplier = 0.1f;
 	protected bool isFiring = false;
 	protected float fireDelay = 0;


### PR DESCRIPTION
-public variable "fireOnlyWhenPlayerNear" in AlgorithmicTurret controls whether a particular one of its children can only fire when the player is within public variable "sensorRange" units away from the turret. CHANGE FOR EACH SPECIFIC TURRET IN THE EDITOR, NOT IN THE AlgorithmicTurret FILE

-LightBullets implemented, not used, likely won't be used. DO NOT TOUCH

-TriangleTurrets fixed. DO NOT TOUCH PRIVATE VARIABLES

-BulletCount script and object made to display number of bullets in the scene on the canvas, currently disabled, probably shouldn't mess with it atm

-PlayerBullet fixed, now shoot correctly again

-Each turret must manually individually be given a target, this being the Player object in the scene, NOT THE PREFAB. This will be optimized later

-Fixed the mysterious disappearance of many critical lines in several turret files.
