### PR TITLE
Checkpoint Camera Fix

### DIFF
--- a/Assets/Scripts/Player/LastCheckpoint.cs
+++ b/Assets/Scripts/Player/LastCheckpoint.cs
@@ -3,8 +3,8 @@ using System.Collections;
 
 public class LastCheckpoint : MonoBehaviour {
 
-	public Vector3 savedPOS;
-	public Quaternion savedROT;
+	public Vector3 savedPlayerPOS, savedCamPOS;
+	public Quaternion savedPlayerROT, savedCamROT;
 	public int shieldCharge;
 	public int bombCharge;
 	public int hullHealth;
@@ -14,8 +14,10 @@ public class LastCheckpoint : MonoBehaviour {
 
 	// Save the initial data upon spawning
 	void Start () {
-		savedPOS = gameObject.transform.position;
-		savedROT = gameObject.transform.rotation;
+		savedPlayerPOS = gameObject.transform.position;
+		savedPlayerROT = gameObject.transform.rotation;
+		savedCamPOS = GameObject.FindGameObjectWithTag("MainCamera").transform.position;
+		savedCamROT = GameObject.FindGameObjectWithTag("MainCamera").transform.rotation;
 		pController = gameObject.GetComponent<PlayerController> ();
 		bomb = GameObject.FindGameObjectWithTag("Bomb").GetComponent<BombController>();
 		bombCharge = bomb.currBombCharge;
@@ -25,12 +27,15 @@ public class LastCheckpoint : MonoBehaviour {
 	}
 
 	//This is usually called by PlayerController during a reload
+	//NOTE: Assumes the main camera exists
 	public void setCheckPoint(int newShield, int newBomb, int newHull, Vector3 newPOS, Quaternion newROT){
 		shieldCharge = newShield;
 		bombCharge = newBomb;
 		hullHealth = newHull;
-		savedPOS = newPOS;
-		savedROT = newROT;
+		savedPlayerPOS = newPOS;
+		savedPlayerROT = newROT;
+		savedCamPOS = GameObject.FindGameObjectWithTag("MainCamera").transform.position;
+		savedCamROT = GameObject.FindGameObjectWithTag("MainCamera").transform.rotation;
 	}
 
 	public int getShield (){ return shieldCharge;}
@@ -39,7 +44,13 @@ public class LastCheckpoint : MonoBehaviour {
 
 	public int getHealth(){ return hullHealth;}
 
-	public Vector3 getCheckPOS(){ return savedPOS;}
+	public Vector3 getCheckPOS(){ return savedPlayerPOS;}
 
-	public Quaternion getCheckROT(){ return savedROT;}
+	public Quaternion getCheckROT(){ return savedPlayerROT;}
+
+	public Vector3 getCheckCamPOS(){return savedCamPOS;}
+
+	public Quaternion getCheckCamROT(){return savedCamROT;}
+
+
 }

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -135,11 +135,13 @@ public class PlayerController : MonoBehaviour {
 		}
 
 		//Count down invulnerability
-		if(timerTMP > 0)
+		if(fInvincible)
 		{
 			timerTMP -= Time.deltaTime;
+			Debug.Log("TimerTMP = " + timerTMP);
 		}
-		else if(timerTMP <= 0)
+
+		if(timerTMP <= 0)
 		{
 			fInvincible = false;
 		}
@@ -283,6 +285,10 @@ public class PlayerController : MonoBehaviour {
 		Debug.Log("Reloading!");
 		gameObject.transform.position = savedData.getCheckPOS();
 		gameObject.transform.rotation = savedData.getCheckROT();
+
+		GameObject.FindGameObjectWithTag("MainCamera").transform.position = savedData.getCheckCamPOS();
+		GameObject.FindGameObjectWithTag("MainCamera").transform.rotation = savedData.getCheckCamROT();
+
 		currHullIntegrity = savedData.getHealth();
 		shield.setCurrShieldCharge(savedData.getShield());
 		GameObject.FindGameObjectWithTag("Bomb").GetComponent<BombController>().currBombCharge = savedData.getBomb();

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -298,12 +298,17 @@ public class PlayerController : MonoBehaviour {
 		//Overwrite data
 		savePlayer ();
 
-		//Turn off turrets
-		GameObject[] allTurrets;
+		//Turn off turrets + Destroy bullets
+		GameObject[] allTurrets, allBullets;
 		allTurrets = GameObject.FindGameObjectsWithTag ("Turret");
+		allBullets = GameObject.FindGameObjectsWithTag ("Projectile");
 		for (int numTurret = 0; numTurret < allTurrets.Length; ++numTurret) {
 			allTurrets [numTurret].GetComponent<Turret> ().TurnOff ();
 		}
+
+		/*for (int numBullet = 0; numBullet < allBullets.Length; ++numBullet) {
+			Destroy(allBullets[numBullet]);
+		}*/
 	}
 
 	//Deactivates player controls and shows game over screen

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -283,16 +283,27 @@ public class PlayerController : MonoBehaviour {
 	public void reloadCheckP (LastCheckpoint savedData)
 	{
 		Debug.Log("Reloading!");
+		//Teleport Player + Camera
 		gameObject.transform.position = savedData.getCheckPOS();
 		gameObject.transform.rotation = savedData.getCheckROT();
 
 		GameObject.FindGameObjectWithTag("MainCamera").transform.position = savedData.getCheckCamPOS();
 		GameObject.FindGameObjectWithTag("MainCamera").transform.rotation = savedData.getCheckCamROT();
 
+		//Reset stats
 		currHullIntegrity = savedData.getHealth();
 		shield.setCurrShieldCharge(savedData.getShield());
 		GameObject.FindGameObjectWithTag("Bomb").GetComponent<BombController>().currBombCharge = savedData.getBomb();
+
+		//Overwrite data
 		savePlayer ();
+
+		//Turn off turrets
+		GameObject[] allTurrets;
+		allTurrets = GameObject.FindGameObjectsWithTag ("Turret");
+		for (int numTurret = 0; numTurret < allTurrets.Length; ++numTurret) {
+			allTurrets [numTurret].GetComponent<Turret> ().TurnOff ();
+		}
 	}
 
 	//Deactivates player controls and shows game over screen


### PR DESCRIPTION
Camera now teleports to last saved position. Turrets in the scene now turn off as well, but note that bullets are not destroyed. 

Time paradoxes may occur if the player is killed by the same bullet twice.
