### PR TITLE
Performance-Up

### DIFF
--- a/Assets/Prefabs/TurretTriggerOFF.prefab
+++ b/Assets/Prefabs/TurretTriggerOFF.prefab
@@ -10,6 +10,7 @@ GameObject:
   - 4: {fileID: 437138}
   - 65: {fileID: 6505846}
   - 114: {fileID: 11449250}
+  - 114: {fileID: 11419958}
   m_Layer: 0
   m_Name: TurretTriggerOFF
   m_TagString: Untagged
@@ -23,9 +24,9 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 109174}
-  m_LocalRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071067}
-  m_LocalPosition: {x: 103.009995, y: -958.9046, z: 2615.5808}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalRotation: {x: 0, y: 0.00000016292068, z: -1.4210855e-14, w: -1}
+  m_LocalPosition: {x: -4685.8, y: -1132.5988, z: -1655.1553}
+  m_LocalScale: {x: 1, y: 1, z: 2.4999998}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -39,8 +40,27 @@ BoxCollider:
   m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 10, y: 75, z: 72.95}
+  m_Size: {x: 10, y: 127.69, z: 75}
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &11419958
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 109174}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7b07b5d6ca0d02040abf3ca12a25a5f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  tagsToTurnOff:
+  - Cooler Light
+  - Relay Light
+  - Breeder Light
+  - Injector Light
+  - Control Light
+  - Capacitor Light
+  - Reactor Light
 --- !u!114 &11449250
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/TurretTriggerON.prefab
+++ b/Assets/Prefabs/TurretTriggerON.prefab
@@ -10,6 +10,7 @@ GameObject:
   - 4: {fileID: 468348}
   - 65: {fileID: 6509560}
   - 114: {fileID: 11464430}
+  - 114: {fileID: 11495022}
   m_Layer: 0
   m_Name: TurretTriggerON
   m_TagString: Untagged
@@ -23,9 +24,9 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 114524}
-  m_LocalRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071067}
-  m_LocalPosition: {x: 2679.51, y: -110.8, z: -246.927}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalRotation: {x: 0, y: 0.00000016292068, z: -1.4210855e-14, w: -1}
+  m_LocalPosition: {x: -4611.5, y: -1132.5991, z: -1655.1556}
+  m_LocalScale: {x: 1, y: 1, z: 2.5000002}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -39,7 +40,7 @@ BoxCollider:
   m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 10, y: 83.6, z: 100}
+  m_Size: {x: 10, y: 159.8, z: 75}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!114 &11464430
 MonoBehaviour:
@@ -54,6 +55,48 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   turretList:
   - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+--- !u!114 &11495022
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 114524}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e844caa947bbb1e40aa12649786c89d0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  lightList: []
 --- !u!1001 &100100000
 Prefab:
   m_ObjectHideFlags: 1

--- a/Assets/TurnLightsOff.cs
+++ b/Assets/TurnLightsOff.cs
@@ -1,0 +1,40 @@
+﻿using UnityEngine;
+using System.Collections;
+using System.Collections.Generic;
+
+public class TurnLightsOff : MonoBehaviour {
+	public string[] tagsToTurnOff;
+
+	private List<GameObject []> arrayList = new List<GameObject []> ();
+	private List<GameObject> lightList = new List<GameObject> ();
+
+	// Use this for initialization
+	void Start () {
+		for(int i = 0; i < tagsToTurnOff.Length; i++){
+			arrayList.Add(GameObject.FindGameObjectsWithTag (tagsToTurnOff[i]));
+		}
+
+		for(int i = 0; i < arrayList.Count; i++){
+			for(int j = 0; j < arrayList[i].Length; j++){
+				lightList.Add(arrayList[i][j]);
+			}
+		}
+	}
+
+	// Update is called once per frame
+	void Update () {
+
+	}
+
+	void OnTriggerEnter (Collider other) {
+		if (other.gameObject.CompareTag ("Player Turret Trigger")) {
+			toggleTurrets ();
+		}
+	}
+
+	void toggleTurrets () {
+		for (int numLight = 0; numLight < lightList.Count; ++numLight) {
+			lightList [numLight].GetComponent<Light> ().enabled = false;
+		}
+	}
+}

--- a/Assets/TurnLightsOff.cs.meta
+++ b/Assets/TurnLightsOff.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 7b07b5d6ca0d02040abf3ca12a25a5f6
+timeCreated: 1462481216
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/TurnLightsOn.cs
+++ b/Assets/TurnLightsOn.cs
@@ -1,0 +1,31 @@
+﻿using UnityEngine;
+using System.Collections;
+using System.Collections.Generic;
+
+public class TurnLightsOn : MonoBehaviour {
+	public string tag = "None";
+
+	private GameObject[] lightList;
+
+	// Use this for initialization
+	void Start () {
+		lightList = GameObject.FindGameObjectsWithTag (tag);
+	}
+
+	// Update is called once per frame
+	void Update () {
+
+	}
+
+	void OnTriggerEnter (Collider other) {
+		if (other.gameObject.CompareTag ("Player Turret Trigger")) {
+			toggleTurrets ();
+		}
+	}
+
+	void toggleTurrets () {
+		for (int numLight = 0; numLight < lightList.Length; ++numLight) {
+			lightList [numLight].GetComponent<Light> ().enabled = true;
+		}
+	}
+}

--- a/Assets/TurnLightsOn.cs.meta
+++ b/Assets/TurnLightsOn.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: e844caa947bbb1e40aa12649786c89d0
+timeCreated: 1462480844
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -43,6 +43,13 @@ TagManager:
   - Color Selector Button
   - Color Slider
   - Powerup Background
+  - Cooler Light
+  - Relay Light
+  - Breeder Light
+  - Injector Light
+  - Control Light
+  - Capacitor Light
+  - Reactor Light
   layers:
   - Default
   - TransparentFX

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -50,6 +50,8 @@ TagManager:
   - Control Light
   - Capacitor Light
   - Reactor Light
+  - HUD Element Sample
+  - Fire
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
A number of performance tweaks:
- Lighting is now only enabled for the room the player is in
- Most lights have their shadows disabled
- Split up the capacitor room further
  - Doesn't seem to have helped too much
- NOTE: There was a merge conflict with the tags when I was updating. Someone who was working on tags put in "Fire" and "HUD Element Sample." Elements using those tags may or may not work now, as I have tags of my own to use for lighting.
